### PR TITLE
Add driver name to dlt database credentials

### DIFF
--- a/dlt-db-replication/README.md
+++ b/dlt-db-replication/README.md
@@ -81,6 +81,7 @@ Create or update the `.dlt/secrets.toml` file with your database credentials:
 ```toml
 # PostgreSQL credentials
 [sources.sql_database.credentials]
+drivername = "postgresql"
 database = "your_database_name"
 host = "your_postgres_host"
 password = "your_postgres_password"


### PR DESCRIPTION
Add driver name to dlt database credentials.

Without this set, I got the following error:
```
dlt.common.configuration.exceptions.ConfigFieldMissingException: Following fields are missing: ['drivername'] in configuration with spec ConnectionStringCredentials
        for field "drivername" config providers and keys were tried in following order:
                In Environment Variables key PG2MD__SOURCES__SQL_DATABASE__SQL_DATABASE__CREDENTIALS__DRIVERNAME was not found.
                In Environment Variables key PG2MD__SOURCES__SQL_DATABASE__CREDENTIALS__DRIVERNAME was not found.
                In Environment Variables key PG2MD__SOURCES__CREDENTIALS__DRIVERNAME was not found.
                In Environment Variables key PG2MD__CREDENTIALS__DRIVERNAME was not found.
                In secrets.toml key pg2md.sources.sql_database.sql_database.credentials.drivername was not found.
                In secrets.toml key pg2md.sources.sql_database.credentials.drivername was not found.
                In secrets.toml key pg2md.sources.credentials.drivername was not found.
                In secrets.toml key pg2md.credentials.drivername was not found.
                In config.toml key pg2md.sources.sql_database.sql_database.credentials.drivername was not found.
                In config.toml key pg2md.sources.sql_database.credentials.drivername was not found.
                In config.toml key pg2md.sources.credentials.drivername was not found.
                In config.toml key pg2md.credentials.drivername was not found.
                In Environment Variables key SOURCES__SQL_DATABASE__SQL_DATABASE__CREDENTIALS__DRIVERNAME was not found.
                In Environment Variables key SOURCES__SQL_DATABASE__CREDENTIALS__DRIVERNAME was not found.
                In Environment Variables key SOURCES__CREDENTIALS__DRIVERNAME was not found.
                In Environment Variables key CREDENTIALS__DRIVERNAME was not found.
                In secrets.toml key sources.sql_database.sql_database.credentials.drivername was not found.
                In secrets.toml key sources.sql_database.credentials.drivername was not found.
                In secrets.toml key sources.credentials.drivername was not found.
                In secrets.toml key credentials.drivername was not found.
                In config.toml key sources.sql_database.sql_database.credentials.drivername was not found.
                In config.toml key sources.sql_database.credentials.drivername was not found.
                In config.toml key sources.credentials.drivername was not found.
                In config.toml key credentials.drivername was not found.
Please refer to https://dlthub.com/docs/general-usage/credentials/ for more information
```