### PR TITLE
Dynamic starter list in get-starter.sh + get.motherduck.com shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ready-to-use starter projects for building with MotherDuck: self-contained, copy
 The fastest way to get started is using the get-starter script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/motherduckdb/motherduck-examples/main/scripts/get-starter.sh | bash -s <starter-name>
+curl -fsSL https://get.motherduck.com | bash -s <starter-name>
 ```
 
 Or browse the available starter projects below. Each folder contains a complete, working example with its own README:
@@ -58,24 +58,24 @@ Each starter project is self-contained. You can:
    cd my-new-project
    ```
 
-3. **Use the get-starter script** (recommended): 
+3. **Use the get-starter script** (recommended):
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/motherduckdb/motherduck-examples/main/scripts/get-starter.sh | bash -s <starter-name>
+   curl -fsSL https://get.motherduck.com | bash -s <starter-name>
    ```
-   
+
    This will download only the starter project you need. For example:
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/motherduckdb/motherduck-examples/main/scripts/get-starter.sh | bash -s dbt-ai-prompt
+   curl -fsSL https://get.motherduck.com | bash -s dbt-ai-prompt
    ```
-   
+
    The script will:
    - Download only the selected starter project (not the entire repo)
    - Use git sparse checkout to fetch just the needed folder
    - Create a clean copy without git history
 
-   **Testing from a PR branch**: Set the `BRANCH` environment variable to test from a PR branch:
+   **Testing from a PR branch**: set the `BRANCH` environment variable and fetch the script from that branch directly (since `get.motherduck.com` always serves the `main` version):
    ```bash
-   BRANCH=feat/reorg curl -fsSL https://raw.githubusercontent.com/motherduckdb/motherduck-examples/feat/reorg/scripts/get-starter.sh | bash -s dbt-ai-prompt
+   BRANCH=my-branch curl -fsSL https://raw.githubusercontent.com/motherduckdb/motherduck-examples/my-branch/scripts/get-starter.sh | bash -s dbt-ai-prompt
    ```
 
 ## Requirements

--- a/scripts/get-starter.sh
+++ b/scripts/get-starter.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # get-starter.sh - Download a specific starter project from motherduck-examples repository
-# 
+#
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/motherduckdb/motherduck-examples/main/scripts/get-starter.sh | bash -s <starter-name>
+#   curl -fsSL https://get.motherduck.com | bash -s <starter-name>
 #
 # This script uses git sparse checkout to download only the selected starter folder
 # without cloning the entire repository.
@@ -19,29 +19,65 @@ NC='\033[0m' # No Color
 # Configuration
 REPO="motherduckdb/motherduck-examples"
 REPO_URL="https://github.com/${REPO}.git"
-# Default to main, but can be overridden via BRANCH env var for PR testing
-# Example: BRANCH=feat/reorg curl -fsSL ... | bash -s dbt-ai-prompt
+# Default to main, but can be overridden via BRANCH env var for PR testing.
+# When testing a PR branch, fetch the script from that branch too (the
+# get.motherduck.com redirector always serves the main branch version):
+#   BRANCH=my-branch curl -fsSL \
+#     https://raw.githubusercontent.com/motherduckdb/motherduck-examples/my-branch/scripts/get-starter.sh \
+#     | bash -s <starter-name>
 BRANCH="${BRANCH:-main}"
 
-# Available starter projects (folder names in the repo)
-AVAILABLE_STARTERS=(
-  "dbt-ai-prompt"
-  "dbt-churn-prediction"
-  "dbt-dual-execution"
-  "dbt-ducklake"
-  "dbt-ingestion-s3"
-  "dbt-local-ducklake"
-  "dbt-metricflow"
-  "dlt-db-replication"
-  "motherduck-grafana"
-  "motherduck-ui"
-  "postgres-demo"
-  "python-ingestion"
-  "sqlmesh-demo"
+# Top-level folders that are not starter projects and should be hidden
+# from the list. Everything else in the repo root is treated as a starter.
+EXCLUDED_DIRS=(
+  "scripts"
+  "landing"
+  "datasets"
+  "theming"
+  ".devcontainer"
+  ".github"
 )
+
+AVAILABLE_STARTERS=()
+
+# Fetch the list of starter folders dynamically from the GitHub API.
+# Populates AVAILABLE_STARTERS. Returns non-zero if fetch fails.
+fetch_starters() {
+  local api_url="https://api.github.com/repos/${REPO}/contents?ref=${BRANCH}"
+  local raw
+  raw=$(curl -fsSL "${api_url}" 2>/dev/null) || return 1
+
+  # Parse pretty-printed JSON: capture "name" then check the following "type": "dir"
+  local dirs
+  dirs=$(echo "${raw}" | awk -F'"' '
+    /"name":/ { name = $4 }
+    /"type":/ { if ($4 == "dir" && name != "") { print name; name = "" } }
+  ')
+
+  AVAILABLE_STARTERS=()
+  local dir excluded ex
+  while IFS= read -r dir; do
+    [ -z "${dir}" ] && continue
+    excluded=false
+    for ex in "${EXCLUDED_DIRS[@]}"; do
+      if [ "${dir}" = "${ex}" ]; then
+        excluded=true
+        break
+      fi
+    done
+    [ "${excluded}" = "false" ] && AVAILABLE_STARTERS+=("${dir}")
+  done <<< "${dirs}"
+
+  [ ${#AVAILABLE_STARTERS[@]} -gt 0 ]
+}
 
 # Function to print available starters
 list_starters() {
+  if [ ${#AVAILABLE_STARTERS[@]} -eq 0 ]; then
+    echo -e "${YELLOW}Could not fetch the list of starter projects from GitHub.${NC}"
+    echo "Browse them at: https://github.com/${REPO}"
+    return
+  fi
   echo -e "${BLUE}Available starter projects:${NC}"
   echo ""
   for starter in "${AVAILABLE_STARTERS[@]}"; do
@@ -64,24 +100,30 @@ starter_exists() {
 # Get starter name from argument
 STARTER_NAME=${1:-}
 
+# Try to populate AVAILABLE_STARTERS from the GitHub API. If this fails
+# (offline, rate-limited, etc.), we fall back to trusting the user's
+# argument and let the sparse-checkout step be the source of truth.
+STARTERS_FETCHED=true
+fetch_starters || STARTERS_FETCHED=false
+
 # If no starter name provided, show usage
 if [ -z "$STARTER_NAME" ]; then
   echo -e "${YELLOW}MotherDuck examples - Get a starter project by name${NC}"
   echo ""
   echo "Usage:"
-  echo "  curl -fsSL https://raw.githubusercontent.com/${REPO}/${BRANCH}/scripts/get-starter.sh | bash -s <starter-name>"
+  echo "  curl -fsSL https://get.motherduck.com | bash -s <starter-name>"
   echo ""
   echo "Or download and run locally:"
   echo "  ./scripts/get-starter.sh <starter-name>"
   echo ""
   list_starters
   echo "Example:"
-  echo "  curl -fsSL https://raw.githubusercontent.com/${REPO}/${BRANCH}/scripts/get-starter.sh | bash -s dbt-ai-prompt"
+  echo "  curl -fsSL https://get.motherduck.com | bash -s dbt-ai-prompt"
   exit 1
 fi
 
-# Check if starter exists
-if ! starter_exists "$STARTER_NAME"; then
+# Check if starter exists (only when we were able to fetch the list)
+if [ "$STARTERS_FETCHED" = "true" ] && ! starter_exists "$STARTER_NAME"; then
   echo -e "${RED}Error: Starter project '${STARTER_NAME}' not found.${NC}"
   echo ""
   list_starters


### PR DESCRIPTION
## Summary

- `scripts/get-starter.sh` now fetches the list of starter folders from the GitHub contents API at runtime instead of a hardcoded array. New starters show up automatically — no script PR needed when adding one (e.g. `cloudflare-workers-duckoffee`, `vercel-nextjs`, etc. already work on this branch).
- Non-starter folders are filtered via a small `EXCLUDED_DIRS` list (`scripts`, `landing`, `datasets`, `theming`, `.devcontainer`, `.github`). One place to maintain going forward.
- Fallback: if the API call fails (offline / rate-limited), validation is skipped and sparse-checkout becomes the source of truth — the user can still pull down a starter they know by name.
- README + script help text now use the shorter `https://get.motherduck.com` redirector. The raw-URL form is kept as the documented path for PR-branch testing, since the redirector always serves `main`.

## Test plan

- [ ] `scripts/get-starter.sh` with no args prints the dynamically fetched list (currently 17 starters on `main`).
- [ ] `scripts/get-starter.sh not-a-real-starter` errors out and re-prints the list.
- [ ] `curl -fsSL https://get.motherduck.com | bash -s cloudflare-workers-duckoffee` downloads the folder into `./cloudflare-workers-duckoffee` (once this PR is merged and the redirector picks it up).
- [ ] `BRANCH=feat/dynamic-starter-list curl -fsSL https://raw.githubusercontent.com/motherduckdb/motherduck-examples/feat/dynamic-starter-list/scripts/get-starter.sh | bash -s cloudflare-workers-duckoffee` works for pre-merge testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)