### PR TITLE
feat(flight-freshness-alert): freshness check + Slack alert Flight template

### DIFF
--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -1,0 +1,182 @@
+---
+title: Alert on Stale Tables From a Flight
+id: flight-freshness-alert
+description: >-
+  A reusable Flight that checks table freshness with dbt-style warn/error age
+  thresholds on a schedule and posts a Slack alert when data goes stale. Use
+  when you want scheduled freshness monitoring on MotherDuck tables with a
+  warn/error severity model and a Slack notification.
+type: template
+features: [flights]
+tags: [slack]
+---
+
+# Alert on Stale Tables From a Flight
+
+A single-file Flight that monitors how fresh your MotherDuck tables are and
+posts a Slack alert when one falls behind. It follows the dbt source-freshness
+model: each table names a timestamp column, and you compare `now() - MAX(column)`
+against a `warn` and an `error` threshold. The Flight schedules the check, writes
+an audit ledger, and pings Slack when something is stale.
+
+Unlike the config-driven templates here, the thing you edit is a `CHECKS` list at
+the top of `flight.py` (much like you replace `repo_rows()` in
+[flight-dlt-ingest](../flight-dlt-ingest)). The defaults point at read-only
+`sample_data`, a frozen ~2022 snapshot, so a fresh deploy always reports `error`
+and fires one Slack message. That doubles as a built-in test that your webhook is
+wired up. Swap `CHECKS` for your own tables before you add a schedule.
+
+## What you'll adjust
+
+The freshness checks live in the `CHECKS` list at the top of `flight.py`; two
+module constants below it control alerting and the ledger. Only the Slack webhook
+and the MotherDuck token come from outside the code.
+
+| Knob | Where | Default | Purpose |
+|---|---|---|---|
+| `CHECKS` | top of `flight.py` | two `sample_data` tables | The list of freshness checks. Replace these entries with your own tables. |
+| `table` (per check) | `CHECKS` entry | `sample_data.hn.hacker_news`, `sample_data.nyc.taxi` | Table to check, as `database.schema.table` or `schema.table`. Each part validated as a SQL identifier. |
+| `column` (per check) | `CHECKS` entry | `timestamp`, `tpep_pickup_datetime` | The timestamp/date column whose `MAX` defines freshness. Use the column that records when a row arrived. |
+| `warn_after_hours` / `error_after_hours` | `CHECKS` entry | `24` / `48` | Age thresholds in hours. `lag >= error` → `error`, `>= warn` → `warn`, else `pass`. |
+| `ALERT_LEVEL` | top of `flight.py` | `warn` | `warn` alerts on warn+error; `error` alerts only on error. |
+| `RESULTS_TABLE` | top of `flight.py` | `flights_demo.main.freshness_check_runs` | Audit ledger target as `database.schema.table`. Must be a writable database. `""` disables the ledger. |
+| `SLACK_WEBHOOK_URL` | Flight secret / env var | (unset) | Slack Incoming Webhook URL. Provide it through a MotherDuck secret, never in code. Unset → the run prints the report and skips Slack. |
+| `MOTHERDUCK_TOKEN` | Flight-injected | (Flight-injected) | Auth. Select a token on the Flight; never hard-code it. |
+
+## Questions to answer
+
+- Which tables need monitoring, and which column on each records when its rows arrive (load time, event time, ingest time)?
+- What `warn`/`error` age thresholds match each table's expected update cadence?
+- Should the alert fire on `warn`, or only on `error`?
+- Which Slack channel receives the alert, and is its Incoming Webhook stored as a MotherDuck secret?
+- Which service account token can read the checked tables and write the ledger?
+- What schedule (cron, UTC) matches how often the data should refresh?
+
+## Run it
+
+You need a MotherDuck account and an access token. With the defaults, the check
+reads two public `sample_data` tables (no extra credentials needed). Provide
+`SLACK_WEBHOOK_URL` only if you want a real Slack post during the smoke test.
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+# optional: actually post to Slack instead of only printing
+export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+uv run --with-requirements requirements.txt flight.py
+```
+
+With the defaults this checks the two frozen `sample_data` tables, prints two
+`error` lines, writes the ledger to `flights_demo.main.freshness_check_runs`, and
+(if `SLACK_WEBHOOK_URL` is set) posts one Slack alert. That confirms the whole
+path before you point `CHECKS` at your own tables.
+
+### Deploy as a Flight
+
+First create the Slack webhook as a MotherDuck secret (best in the MotherDuck
+console; also works via the `query_rw` MCP tool or a direct SQL connection):
+
+```sql
+CREATE SECRET freshness_slack IN motherduck (
+  TYPE flights,
+  PARAMS MAP { 'SLACK_WEBHOOK_URL': 'https://hooks.slack.com/services/...' }
+);
+```
+
+Then deploy with the MotherDuck MCP server rather than checked-in SQL. Call
+`get_flight_guide` first for the exact tool arguments, then `create_flight` with:
+
+- `source_code`: the contents of [`flight.py`](flight.py), with `CHECKS` edited to your tables
+- `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `access_token_name`: a service account token that can read the checked tables
+  and write `RESULTS_TABLE` (list tokens with the `md_access_tokens()` table
+  function); the runtime injects its value as `MOTHERDUCK_TOKEN`
+- `flight_secret_names`: `["freshness_slack"]` so `SLACK_WEBHOOK_URL` is injected
+
+No `config` is needed: every knob lives in the code.
+
+Create the Flight without a schedule first, trigger one manual run with
+`run_flight`, and confirm it succeeds and a Slack alert arrives. Then edit
+`CHECKS` to your real tables and add a schedule (for example `0 * * * *`, hourly)
+by updating the Flight's `schedule_cron`. Schedule updates are metadata-only and
+do not create a new Flight version.
+
+## How it works
+
+`flight.py` runs a fixed sequence; only the `CHECKS` list changes its inputs:
+
+1. Connect to MotherDuck (`md:`).
+2. For each check, run `SELECT max(column), date_diff('hour', max(column), now())`
+   and assign `pass` / `warn` / `error` from the two thresholds. The comparison
+   is done in SQL against the runtime clock, so it follows the runtime timezone
+   (see [Time zones](#time-zones)). A missing table/column or an empty table is
+   recorded as `error` for that one check, not raised, so a single typo does not
+   hide the other checks.
+3. Write one ledger row per check to `RESULTS_TABLE` (its database and schema are
+   created on first run, since `sample_data` is read-only).
+4. Print the report. If any check is at or above `ALERT_LEVEL` and
+   `SLACK_WEBHOOK_URL` is set, POST a Slack Block Kit message listing each stale
+   table with its lag and severity.
+
+## Time zones
+
+Freshness is `now() - MAX(column)`, computed in the database, so the comparison
+uses the **runtime's clock and timezone**. A deployed Flight runs in **UTC**; a
+local `uv run` uses your machine's timezone. Two consequences:
+
+- **`TIMESTAMPTZ` columns are unambiguous.** They carry an offset, so the age and
+  the stored `max_timestamp` are correct no matter where the code runs. Prefer
+  these.
+- **Naive `TIMESTAMP` columns are read in the runtime timezone.** A value like
+  `2024-01-01 09:00:00` with no offset is treated as 09:00 *in the runtime tz*
+  (UTC on a Flight). If your naive timestamps are actually stored in another
+  timezone, the computed age is off by that UTC offset, and the `max_timestamp`
+  written to the ledger reflects the runtime tz. Deploy as a Flight (UTC) for
+  consistent results, or store source timestamps as `TIMESTAMPTZ`.
+
+**Why `pytz` is a dependency.** Reading a `TIMESTAMPTZ` value back into Python as a
+tz-aware `datetime` requires `pytz`. The duckdb wheel ships with no required
+dependencies (timezone math inside the engine uses the bundled ICU extension), so
+`pytz` is not installed automatically; without it, a check on a `TIMESTAMPTZ`
+column fails with `Required module 'pytz' failed to import`. It is pinned next to
+`duckdb` in `requirements.txt` so checks work on tz-aware columns.
+
+## Caveats
+
+- **The default `CHECKS` always alert.** `sample_data` is a read-only ~2022
+  snapshot, so both default checks report `error` every run. This is intentional:
+  it proves a fresh deploy can reach Slack. Replace `CHECKS` with your own tables
+  before adding a schedule, or you will get a Slack message on every run.
+- **Pick the right column.** Freshness is `MAX(column)`. Use the column that
+  records when a row landed (load, ingest, or event time), not an unrelated date.
+- **Failures degrade per check.** A missing table/column or an empty table is
+  recorded as `error` for that check with the reason, rather than aborting the run.
+- **A broken webhook fails the run.** A configured `SLACK_WEBHOOK_URL` that returns
+  an error raises after the ledger is written, so a broken alert path shows up as a
+  FAILED run instead of silently dropping the alert.
+- **The ledger needs a writable database.** `RESULTS_TABLE` must live in a database
+  you can write to; the Flight creates `flights_demo` if it is missing. Set
+  `RESULTS_TABLE = ""` to skip the ledger.
+- **Keep secrets out of code.** Put the webhook in a MotherDuck secret and select a
+  token on the Flight; never hard-code either.
+
+## Security
+
+- **Identifier validation.** Each `CHECKS` table (split on `.`) and column, and
+  `RESULTS_TABLE`, are checked against `^[A-Za-z_][A-Za-z0-9_]*$` before any SQL
+  runs, because they flow into `CREATE`/`SELECT`/`INSERT` statements that cannot be
+  parameterized.
+- **Parameterized data.** Ledger rows (table name, column, timestamps, lag, status,
+  detail) are written with bound parameters, never string-formatted into SQL.
+- **Secret-based webhook.** `SLACK_WEBHOOK_URL` is read from a MotherDuck secret or
+  env var at runtime, never hard-coded or placed in Flight config.
+
+## Learn more
+
+- Flight mechanics (creating, running, scheduling): use the MotherDuck MCP
+  `get_flight_guide` tool.
+- Slack delivery: [Incoming Webhooks](https://api.slack.com/messaging/webhooks) and
+  [Block Kit](https://api.slack.com/block-kit) for the message format.
+- Deeper MotherDuck or DuckDB questions: use the `ask_docs_question` MCP tool.
+- Files in this template: [`flight.py`](flight.py) (the single-file Flight source)
+  and [`requirements.txt`](requirements.txt) (`duckdb`, `httpx`, `pytz` — see
+  [Time zones](#time-zones)).

--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -56,7 +56,8 @@ and the MotherDuck token come from outside the code.
 
 You need a MotherDuck account and an access token. With the defaults, the check
 reads two public `sample_data` tables (no extra credentials needed). Provide
-`SLACK_WEBHOOK_URL` only if you want a real Slack post during the smoke test.
+`SLACK_WEBHOOK_URL` only if you want a real Slack post during the smoke test (see
+[Create the Slack webhook](#create-the-slack-webhook) below to get one).
 
 ```bash
 export MOTHERDUCK_TOKEN=your_token_here
@@ -70,10 +71,43 @@ With the defaults this checks the two frozen `sample_data` tables, prints two
 (if `SLACK_WEBHOOK_URL` is set) posts one Slack alert. That confirms the whole
 path before you point `CHECKS` at your own tables.
 
+### Create the Slack webhook
+
+Skip this if you only want the printed report. To post to Slack, create one
+Incoming Webhook and reuse its URL (see the
+[Slack incoming webhooks docs](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/)):
+
+1. Open [api.slack.com/apps?new_app=1](https://api.slack.com/apps?new_app=1) and choose **From a manifest**.
+2. Select your workspace.
+3. Paste this manifest (it only sets the app name; rename it if you like), then review and create the app:
+   ```json
+   {
+       "display_information": {
+           "name": "Fresh Ducks"
+       },
+       "settings": {
+           "org_deploy_enabled": false,
+           "socket_mode_enabled": false,
+           "is_hosted": false,
+           "token_rotation_enabled": false
+       }
+   }
+   ```
+4. Open **Incoming Webhooks** in the app settings (`https://api.slack.com/apps/<APP_ID>/incoming-webhooks`),
+   toggle **Activate Incoming Webhooks** on, click **Add New Webhook to Workspace**, pick the
+   destination channel, and **Authorize**.
+5. Copy the generated webhook URL (it looks like `https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXX`)
+   and use it as `SLACK_WEBHOOK_URL`: an env var for a local run, or the secret below for a Flight.
+
+The webhook URL is a secret and is tied to the one channel you picked. Keep it out
+of code and version control (store it as a MotherDuck secret for a Flight); Slack
+revokes webhook URLs that leak.
+
 ### Deploy as a Flight
 
-First create the Slack webhook as a MotherDuck secret (best in the MotherDuck
-console; also works via the `query_rw` MCP tool or a direct SQL connection):
+Store the webhook URL from [Create the Slack webhook](#create-the-slack-webhook) as
+a MotherDuck secret (best in the MotherDuck console; also works via the `query_rw`
+MCP tool or a direct SQL connection):
 
 ```sql
 CREATE SECRET freshness_slack IN motherduck (

--- a/flight-plans/flight-freshness-alert/flight.py
+++ b/flight-plans/flight-freshness-alert/flight.py
@@ -174,8 +174,9 @@ def send_slack_alert(webhook: str, firing: list[dict]) -> None:
             detail = r["detail"] or "no data"
         else:
             detail = (
-                f"{r['lag_hours']:.0f}h old "
-                f"(warn after {r['warn_after_hours']:.0f}h, error after {r['error_after_hours']:.0f}h)"
+                f"{humanize_hours(r['lag_hours'])} old "
+                f"(warn after {humanize_hours(r['warn_after_hours'])}, "
+                f"error after {humanize_hours(r['error_after_hours'])})"
             )
         lines.append(f"{emoji} *{r['table']}* — {r['status'].upper()}: {detail}")
 
@@ -201,10 +202,41 @@ def format_line(r: dict) -> str:
         return f"[{r['status'].upper():5}] {r['table']} ({r['column']}): {r['detail']}"
     return (
         f"[{r['status'].upper():5}] {r['table']} ({r['column']}): "
-        f"{r['lag_hours']:.0f}h old "
-        f"(warn>{r['warn_after_hours']:.0f}h, error>{r['error_after_hours']:.0f}h); "
+        f"{humanize_hours(r['lag_hours'])} old "
+        f"(warn after {humanize_hours(r['warn_after_hours'])}, "
+        f"error after {humanize_hours(r['error_after_hours'])}); "
         f"max {r['max_ts']}"
     )
+
+
+def humanize_hours(hours: float) -> str:
+    # Turn an age in hours into the largest natural unit (hours, days, months,
+    # years), so an alert reads "3 years, 7 months" instead of "31203h". The
+    # ledger still stores the exact numeric lag_hours; this is display only.
+    h = float(hours)
+    if h < 1:
+        return "under 1 hour"
+    if round(h) < 24:
+        return _plural(round(h), "hour")
+    days = h / 24
+    if round(days) < 60:
+        return _plural(round(days), "day")
+    months = days / 30.44  # average days per month
+    if round(months) < 12:
+        return _plural(round(months), "month")
+    years = days / 365.25
+    whole_years = int(years)
+    extra_months = round((years - whole_years) * 12)
+    if extra_months >= 12:  # rounding can push remainder to a full year
+        whole_years += 1
+        extra_months -= 12
+    if extra_months:
+        return f"{_plural(whole_years, 'year')}, {_plural(extra_months, 'month')}"
+    return _plural(whole_years, "year")
+
+
+def _plural(n: int, unit: str) -> str:
+    return f"{n} {unit}" if n == 1 else f"{n} {unit}s"
 
 
 def validate_identifier(name: str, value: str) -> str:

--- a/flight-plans/flight-freshness-alert/flight.py
+++ b/flight-plans/flight-freshness-alert/flight.py
@@ -1,0 +1,239 @@
+import os
+import re
+
+import duckdb
+import httpx
+
+
+# ---- Configure your freshness checks here --------------------------------
+# Each entry is a table, the timestamp column that records when its rows
+# arrived, and warn/error age thresholds in hours (dbt-style source freshness):
+# lag = now() - MAX(column); lag >= error_after_hours -> "error",
+# lag >= warn_after_hours -> "warn", otherwise "pass".
+#
+# The defaults point at read-only `sample_data`, a frozen ~2022 snapshot, so a
+# fresh deploy always reports "error" and fires a Slack message: a built-in test
+# that your webhook is wired up. Replace these with your own tables before you
+# schedule the Flight, or it will alert on every run.
+CHECKS = [
+    {
+        "table": "sample_data.hn.hacker_news",
+        "column": "timestamp",
+        "warn_after_hours": 24,
+        "error_after_hours": 48,
+    },
+    {
+        "table": "sample_data.nyc.taxi",
+        "column": "tpep_pickup_datetime",
+        "warn_after_hours": 24,
+        "error_after_hours": 48,
+    },
+]
+
+# "warn" alerts on warn+error; "error" alerts only on error.
+ALERT_LEVEL = "warn"
+
+# Per-run audit ledger, written as database.schema.table. Must be a writable
+# database (sample_data is read-only). Set to "" to skip the ledger.
+RESULTS_TABLE = "flights_demo.main.freshness_check_runs"
+# --------------------------------------------------------------------------
+
+
+IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+# Ordered so "warn" as the alert level also covers "error".
+STATUS_RANK = {"pass": 0, "warn": 1, "error": 2}
+
+
+def main() -> None:
+    alert_level = ALERT_LEVEL.strip().lower()
+    if alert_level not in {"warn", "error"}:
+        raise ValueError(f"ALERT_LEVEL must be 'warn' or 'error', got {ALERT_LEVEL!r}")
+    if not CHECKS:
+        print("CHECKS is empty; nothing to check.")
+        return
+
+    con = duckdb.connect("md:")
+    results = [evaluate(con, check) for check in CHECKS]
+
+    for result in results:
+        print(format_line(result))
+
+    if RESULTS_TABLE.strip():
+        write_ledger(con, RESULTS_TABLE.strip(), results)
+    con.close()
+
+    # Alert when any check reaches the configured level. Do this after the ledger
+    # write so a failing webhook still leaves an audit trail.
+    threshold = STATUS_RANK[alert_level]
+    firing = [r for r in results if STATUS_RANK[r["status"]] >= threshold]
+    webhook = os.environ.get("SLACK_WEBHOOK_URL", "").strip()
+
+    if not firing:
+        print(f"All checks within thresholds (alert level '{alert_level}'); no alert sent.")
+        return
+    if not webhook:
+        print(
+            f"{len(firing)} check(s) at/above '{alert_level}', "
+            "but SLACK_WEBHOOK_URL is not set; skipping Slack."
+        )
+        return
+
+    send_slack_alert(webhook, firing)
+    print(f"Sent Slack alert for {len(firing)} check(s).")
+
+
+def evaluate(con: duckdb.DuckDBPyConnection, check: dict) -> dict:
+    # Validate first: the table and column names flow into SQL that cannot be
+    # parameterized, so reject anything that is not a plain SQL identifier.
+    table = validate_table(check["table"])
+    column = validate_identifier("column", check["column"])
+    warn_after = float(check["warn_after_hours"])
+    error_after = float(check["error_after_hours"])
+    base = {
+        "table": check["table"],
+        "column": check["column"],
+        "warn_after_hours": warn_after,
+        "error_after_hours": error_after,
+    }
+
+    try:
+        # Freshness is computed in SQL against the runtime clock (now()), so it
+        # follows the Flight's timezone (UTC). A TIMESTAMPTZ column is compared
+        # unambiguously; a naive TIMESTAMP column is read in the runtime timezone.
+        # Reading max() back as a real timestamp needs pytz for TIMESTAMPTZ
+        # columns (it is in requirements.txt). See the README "Time zones" section.
+        max_ts, lag_hours = con.execute(
+            f"SELECT max({column}) AS max_ts, "
+            f"date_diff('hour', max({column}), now()) AS lag_hours "
+            f"FROM {table}"
+        ).fetchone()
+    except duckdb.Error as exc:
+        # A missing table/column should not blind the other checks: record this
+        # one as an error with the reason and move on.
+        return {**base, "max_ts": None, "lag_hours": None, "status": "error",
+                "detail": str(exc).splitlines()[0]}
+
+    if max_ts is None:
+        return {**base, "max_ts": None, "lag_hours": None, "status": "error",
+                "detail": "table is empty or column is all NULL"}
+
+    lag = float(lag_hours)
+    if lag >= error_after:
+        status = "error"
+    elif lag >= warn_after:
+        status = "warn"
+    else:
+        status = "pass"
+    return {**base, "max_ts": max_ts, "lag_hours": lag, "status": status, "detail": ""}
+
+
+def write_ledger(con: duckdb.DuckDBPyConnection, target: str, results: list[dict]) -> None:
+    database, schema, _table = split_results_table(target)
+    # The ledger lives in a writable database, so create it (and its schema) on
+    # first run; sample_data is read-only and only ever read from.
+    con.execute(f"CREATE DATABASE IF NOT EXISTS {database}")
+    con.execute(f"CREATE SCHEMA IF NOT EXISTS {database}.{schema}")
+    con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {target} (
+            run_at TIMESTAMPTZ,
+            table_name VARCHAR,
+            timestamp_column VARCHAR,
+            max_timestamp TIMESTAMPTZ,
+            lag_hours DOUBLE,
+            warn_after_hours DOUBLE,
+            error_after_hours DOUBLE,
+            status VARCHAR,
+            detail VARCHAR
+        )
+        """
+    )
+    # One bulk multi-row INSERT (not executemany / row-by-row) with bound
+    # parameters. run_at uses now() so every row in a run shares one timestamp.
+    row_sql = "(now(), ?, ?, ?, ?, ?, ?, ?, ?)"
+    params: list = []
+    for r in results:
+        params.extend([
+            r["table"], r["column"], r["max_ts"], r["lag_hours"],
+            r["warn_after_hours"], r["error_after_hours"], r["status"], r["detail"],
+        ])
+    con.execute(
+        f"INSERT INTO {target} "
+        "(run_at, table_name, timestamp_column, max_timestamp, lag_hours, "
+        "warn_after_hours, error_after_hours, status, detail) VALUES "
+        + ", ".join([row_sql] * len(results)),
+        params,
+    )
+
+
+def send_slack_alert(webhook: str, firing: list[dict]) -> None:
+    lines = []
+    for r in firing:
+        emoji = ":red_circle:" if r["status"] == "error" else ":large_yellow_circle:"
+        if r["lag_hours"] is None:
+            detail = r["detail"] or "no data"
+        else:
+            detail = (
+                f"{r['lag_hours']:.0f}h old "
+                f"(warn after {r['warn_after_hours']:.0f}h, error after {r['error_after_hours']:.0f}h)"
+            )
+        lines.append(f"{emoji} *{r['table']}* — {r['status'].upper()}: {detail}")
+
+    blocks = [
+        {"type": "header", "text": {"type": "plain_text", "text": "Data freshness alert", "emoji": True}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}},
+        {"type": "context", "elements": [
+            {"type": "mrkdwn", "text": f"{len(firing)} table(s) past their freshness threshold"}
+        ]},
+    ]
+    response = httpx.post(
+        webhook,
+        json={"text": f"Data freshness alert: {len(firing)} table(s) stale", "blocks": blocks},
+        timeout=30,
+    )
+    # A configured-but-failing webhook should surface as a FAILED run so you
+    # notice that alerting itself is broken; the ledger is already written.
+    response.raise_for_status()
+
+
+def format_line(r: dict) -> str:
+    if r["lag_hours"] is None:
+        return f"[{r['status'].upper():5}] {r['table']} ({r['column']}): {r['detail']}"
+    return (
+        f"[{r['status'].upper():5}] {r['table']} ({r['column']}): "
+        f"{r['lag_hours']:.0f}h old "
+        f"(warn>{r['warn_after_hours']:.0f}h, error>{r['error_after_hours']:.0f}h); "
+        f"max {r['max_ts']}"
+    )
+
+
+def validate_identifier(name: str, value: str) -> str:
+    if not IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a simple SQL identifier, got {value!r}")
+    return value
+
+
+def validate_table(value: str) -> str:
+    # Accept database.schema.table or schema.table; validate each part so the
+    # name is safe to interpolate into SQL that cannot be parameterized.
+    parts = value.split(".")
+    if len(parts) not in (2, 3):
+        raise ValueError(
+            f"table must be 'database.schema.table' or 'schema.table', got {value!r}"
+        )
+    for part in parts:
+        validate_identifier("table part", part)
+    return value
+
+
+def split_results_table(value: str) -> tuple[str, str, str]:
+    parts = value.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"RESULTS_TABLE must be 'database.schema.table', got {value!r}")
+    for part in parts:
+        validate_identifier("RESULTS_TABLE part", part)
+    return parts[0], parts[1], parts[2]
+
+
+if __name__ == "__main__":
+    main()

--- a/flight-plans/flight-freshness-alert/requirements.txt
+++ b/flight-plans/flight-freshness-alert/requirements.txt
@@ -1,0 +1,6 @@
+duckdb==1.5.2
+httpx==0.28.1
+# pytz lets the duckdb Python client return TIMESTAMP WITH TIME ZONE columns as
+# tz-aware datetimes; duckdb has no required dependencies, so it is not pulled in
+# automatically. See the README "Time zones" section.
+pytz==2026.2

--- a/scripts/build-catalog.py
+++ b/scripts/build-catalog.py
@@ -70,6 +70,8 @@ ALLOWED_TAGS = {
     "durable-objects",
     "docker",
     "grafana",
+    # messaging and alerting
+    "slack",
     # external databases
     "postgres",
     "sqlite",


### PR DESCRIPTION
Adds a new `flight-plans/flight-freshness-alert` template: a single-file Flight that checks dbt-style table freshness (warn/error hour thresholds) and posts a Slack alert when data goes stale. The checks live in a `CHECKS` list at the top of `flight.py` and default to read-only `sample_data`, so a fresh deploy always alerts and doubles as a built-in webhook test. The Slack webhook comes from an optional MotherDuck secret, each run writes an audit ledger, table and column identifiers are validated before they reach SQL, and a README "Time zones" section explains the `pytz` dependency and the runtime-timezone behavior. It also adds `slack` to the curated catalog tag list in `scripts/build-catalog.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
