### PR TITLE
fix(flight-freshness-alert): resolve Slack webhook from prefixed secret env var

### DIFF
--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -40,7 +40,7 @@ and the MotherDuck token come from outside the code.
 | `warn_after_hours` / `error_after_hours` | `CHECKS` entry | `24` / `48` | Age thresholds in hours. `lag >= error` → `error`, `>= warn` → `warn`, else `pass`. |
 | `ALERT_LEVEL` | top of `flight.py` | `warn` | `warn` alerts on warn+error; `error` alerts only on error. |
 | `RESULTS_TABLE` | top of `flight.py` | `flights_demo.main.freshness_check_runs` | Audit ledger target as `database.schema.table`. Must be a writable database. `""` disables the ledger. |
-| `SLACK_WEBHOOK_URL` | Flight secret / env var | (unset) | Slack Incoming Webhook URL. Provide it through a MotherDuck secret, never in code. Unset → the run prints the report and skips Slack. |
+| `SLACK_WEBHOOK_URL` | Flight secret / env var | (unset) | Slack Incoming Webhook URL. Provide it through a MotherDuck secret, never in code. As a Flight the secret arrives as `<secret_name>_SLACK_WEBHOOK_URL`; `flight.py` resolves either name. Unset → the run prints the report and skips Slack. |
 | `MOTHERDUCK_TOKEN` | Flight-injected | (Flight-injected) | Auth. Select a token on the Flight; never hard-code it. |
 
 ## Questions to answer
@@ -116,6 +116,13 @@ CREATE SECRET freshness_slack IN motherduck (
 );
 ```
 
+A `TYPE flights` secret injects each param under the env var
+`<secret_name>_<PARAM>`, not the bare param name: the param above arrives as
+`freshness_slack_SLACK_WEBHOOK_URL`, not `SLACK_WEBHOOK_URL`. (DuckDB lowercases
+the unquoted secret name into the prefix.) `flight.py` handles this: it reads
+`SLACK_WEBHOOK_URL` for local runs and otherwise picks up any env var ending in
+`_SLACK_WEBHOOK_URL`, so the secret name you choose does not matter.
+
 Then deploy with the MotherDuck MCP server rather than checked-in SQL. Call
 `get_flight_guide` first for the exact tool arguments, then `create_flight` with:
 
@@ -124,7 +131,8 @@ Then deploy with the MotherDuck MCP server rather than checked-in SQL. Call
 - `access_token_name`: a service account token that can read the checked tables
   and write `RESULTS_TABLE` (list tokens with the `md_access_tokens()` table
   function); the runtime injects its value as `MOTHERDUCK_TOKEN`
-- `flight_secret_names`: `["freshness_slack"]` so `SLACK_WEBHOOK_URL` is injected
+- `flight_secret_names`: `["freshness_slack"]` so the webhook is injected (as
+  `freshness_slack_SLACK_WEBHOOK_URL`; `flight.py` resolves it)
 
 No `config` is needed: every knob lives in the code.
 

--- a/flight-plans/flight-freshness-alert/flight.py
+++ b/flight-plans/flight-freshness-alert/flight.py
@@ -66,7 +66,7 @@ def main() -> None:
     # write so a failing webhook still leaves an audit trail.
     threshold = STATUS_RANK[alert_level]
     firing = [r for r in results if STATUS_RANK[r["status"]] >= threshold]
-    webhook = os.environ.get("SLACK_WEBHOOK_URL", "").strip()
+    webhook = resolve_webhook()
 
     if not firing:
         print(f"All checks within thresholds (alert level '{alert_level}'); no alert sent.")
@@ -74,12 +74,29 @@ def main() -> None:
     if not webhook:
         print(
             f"{len(firing)} check(s) at/above '{alert_level}', "
-            "but SLACK_WEBHOOK_URL is not set; skipping Slack."
+            "but no SLACK_WEBHOOK_URL was found in the environment; skipping Slack."
         )
         return
 
     send_slack_alert(webhook, firing)
     print(f"Sent Slack alert for {len(firing)} check(s).")
+
+
+def resolve_webhook() -> str:
+    # A local run sets SLACK_WEBHOOK_URL directly (see "Run it"). Deployed as a
+    # Flight, the webhook comes from a `TYPE flights` secret, and MotherDuck
+    # injects each secret param under the env var `<secret_name>_<PARAM>`, NOT
+    # the bare param name. So a secret named `freshness_slack` with a
+    # `SLACK_WEBHOOK_URL` param arrives as `freshness_slack_SLACK_WEBHOOK_URL`.
+    # Accept both: the exact name first (local), then any var ending in the
+    # suffix (the secret, whatever you named it).
+    direct = os.environ.get("SLACK_WEBHOOK_URL", "").strip()
+    if direct:
+        return direct
+    for key, value in os.environ.items():
+        if key.endswith("_SLACK_WEBHOOK_URL") and value.strip():
+            return value.strip()
+    return ""
 
 
 def evaluate(con: duckdb.DuckDBPyConnection, check: dict) -> dict:


### PR DESCRIPTION
## What

A MotherDuck `TYPE flights` secret injects each param into the flight container as the env var `<secret_name>_<PARAM>`, **not** the bare param name. The freshness-alert example read the bare `SLACK_WEBHOOK_URL`, so the documented `freshness_slack` secret arrived as `freshness_slack_SLACK_WEBHOOK_URL` and the lookup missed it.

Net effect: a **deployed Flight** silently printed `skipping Slack` and never alerted, even though the local smoke test (which exports a bare `SLACK_WEBHOOK_URL`) worked and masked the bug.

I verified the naming behaviour empirically (throwaway secret + probe flight): params surface as `<secret_name>_<PARAM>`, secret name lowercased by DuckDB, param key case preserved. This matches the now-corrected upstream flight guide.

## Change

- `flight.py`: add `resolve_webhook()` — prefer the exact `SLACK_WEBHOOK_URL` (local runs), then fall back to any env var ending in `_SLACK_WEBHOOK_URL` (the secret, whatever its name). Works for both paths and any secret name.
- `README.md`: document the `<secret_name>_` prefix in the deploy section, the knobs table, and the `flight_secret_names` note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)