### PR TITLE
Add flight-postgres-ingest Flight Plan template

### DIFF
--- a/flight-plans/flight-postgres-ingest/README.md
+++ b/flight-plans/flight-postgres-ingest/README.md
@@ -1,0 +1,186 @@
+---
+title: Mirror PostgreSQL Tables into MotherDuck With a Flight
+id: flight-postgres-ingest
+description: >-
+  A reusable Flight that mirrors PostgreSQL base tables into MotherDuck through
+  the DuckDB postgres extension, one streaming full-refresh CREATE OR REPLACE per
+  table, with config-driven schema/table selection, idempotent re-runs, retries
+  with backoff, and a per-table audit log. Use it for a config-driven, re-runnable
+  Postgres to MotherDuck ingest.
+type: template
+features: [flights]
+tags: [postgres, ingest, migrate]
+---
+
+# Mirror PostgreSQL Tables into MotherDuck With a Flight
+
+A single-file Flight that copies PostgreSQL base tables into a MotherDuck
+database. 
+
+The pattern is a **full-refresh, atomic swap per table**. Each run attaches
+Postgres read-only via the DuckDB `postgres` extension, discovers the base
+tables in scope, and moves each with one statement:
+`CREATE OR REPLACE TABLE <target>."<schema>"."<table>" AS SELECT * FROM pg."<schema>"."<table>"`.
+That is the whole load — ATOMIC (swaps in one step), IDEMPOTENT (no watermark to
+drift), and STREAMING (flat memory even on large tables). Python only
+orchestrates discovery, retries, and logging. 
+A logging table is created in the target database also.
+
+Full refresh is the simplest correct choice for mutable tables; 
+If you have very large tables (billions of rows), consider incremental/append/CDC
+and use a different Flight template or modify this one heavily.
+
+## What you'll adjust
+
+No code edits are required (code edits are optional). 
+Everything is read from Flight config/env and a MotherDuck flights secret. 
+The MotherDuck **Flights secret** named `pg` contains the Postgres connection information
+which includes a password, so it must be in a secret. If a different secret name is desired, 
+update the SECRET_NAME variable in the code.
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `TARGET_DATABASE` | `postgres_ingest` | MotherDuck database for the mirror (created if absent). Tables land at `<target>.<schema>.<table>`, preserving source schema names. |
+| `INCLUDED_SCHEMAS` | (all non-system) | Comma-separated source schemas to include. Empty = all. |
+| `EXCLUDED_SCHEMAS` | (none) | Comma-separated schemas to drop. Exclude wins. |
+| `INCLUDED_TABLES` | (all) | Comma-separated `schema.table` to include. Empty = all in selected schemas. |
+| `EXCLUDED_TABLES` | (none) | Comma-separated `schema.table` to drop. Exclude wins. |
+| `MAX_RETRIES` | `5` | Per-table retry attempts on transient errors. |
+| `RETRY_BASE_SECONDS` | `2` | Exponential-backoff multiplier (seconds). |
+| `MOTHERDUCK_HOST` | (unset) | Override MotherDuck host (e.g. non-prod). Leave unset for default. |
+| `pg` **secret** | (required) | Postgres connection. `TYPE flights` secret named `pg` with params `HOST`, `PORT`, `DATABASE`, `USER`, `PASSWORD`, `SSLMODE`. |
+
+Selection precedence: a table is mirrored only if its schema passes the schema
+gate **and** its `schema.table` passes the table gate; excludes are `AND NOT` at
+every level, so exclude always wins (including a table whose schema is excluded).
+System schemas (`information_schema`, `pg_catalog`, `pg_toast`, `pg_temp*`) are
+always excluded.
+
+Two gotchas with the `pg` secret:
+- **KEYS must be UPPERCASE.** The secret injects each param as `pg_<KEY>` (e.g.
+  `pg_HOST`), which `flight.py` reads via `PG_PARAMS`.
+- **Code edits are required to use a name other than `pg`.** DuckDB lowercases the secret name into the prefix.
+  Rename the secret only if you also change `SECRET_NAME` in `flight.py`.
+
+## Questions to answer
+
+- Postgres source: host, port, database, user, SSL mode — and which password? Enter as a MotherDuck secret.
+- Which schemas/tables to mirror: everything non-system, one schema, or an explicit allow/deny list?
+- Which `TARGET_DATABASE` should receive the mirror?
+- Is a full refresh per run acceptable given table sizes? (See [Caveats](#caveats).)
+- What schedule (cron, UTC) matches source change rate and freshness needs?
+- Any exotic Postgres column types that the DuckDB Postgres extension can't map that should be excluded?
+
+## Run it
+
+You need a MotherDuck account and token, plus a reachable Postgres source. For a
+local run, set the same `pg_*` names the secret would inject (no credential-free
+smoke test — a reachable Postgres is required).
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+# Postgres connection (same names the `pg` Flights secret injects):
+export pg_HOST=your-postgres-host
+export pg_PORT=5432
+export pg_DATABASE=your_database
+export pg_USER=readonly_user
+export pg_PASSWORD=your_password
+export pg_SSLMODE=require
+# optional: narrow scope / pick a destination
+# export TARGET_DATABASE=postgres_ingest
+# export INCLUDED_SCHEMAS=public
+# export EXCLUDED_TABLES=public.huge_audit_log
+uv run --with-requirements requirements.txt flight.py
+```
+
+This connects to MotherDuck, loads the `postgres` extension, ATTACHes the source
+`READ_ONLY`, creates `TARGET_DATABASE` and the `main.flight_tracker` audit table,
+discovers base tables, applies the gates, and mirrors each selected table with a
+full-refresh `CREATE OR REPLACE`. One log line per table plus a summary; exits
+non-zero if any table failed after retries.
+
+### Deploy as a Flight
+
+First store the connection as a **Flights secret** named `pg` (UI:
+[Settings > Secrets](https://app.motherduck.com/settings/secrets), type
+**Flights**). Or via SQL from a write connection (the read-only `query` MCP tool
+rejects `CREATE SECRET`; use `query_rw` or a direct connection):
+
+```sql
+CREATE SECRET pg IN motherduck (
+  TYPE flights,
+  PARAMS MAP {
+    'HOST': 'your-postgres-host',
+    'PORT': '5432',
+    'DATABASE': 'your_database',
+    'USER': 'readonly_user',
+    'PASSWORD': 'your_password',
+    'SSLMODE': 'require'
+  }
+);
+```
+
+Then deploy with the MotherDuck MCP server (not checked-in SQL). Call
+`get_flight_guide` first for exact tool arguments, then `create_flight` with:
+
+- `source_code`: [`flight.py`](flight.py) (no edits for the default "mirror everything non-system")
+- `requirements_txt`: [`requirements.txt`](requirements.txt)
+- `access_token_name`: a token that can write `TARGET_DATABASE` (list via `md_access_tokens()`); injected as `MOTHERDUCK_TOKEN`
+- `flight_secret_names`: `["pg"]` so the Postgres connection is injected
+- `config`: at least `TARGET_DATABASE`, plus any `INCLUDED_*`/`EXCLUDED_*` scoping and `MOTHERDUCK_HOST` if non-default. The connection stays in the `pg` secret, never config.
+
+Create without a schedule, run once with `run_flight`, and confirm
+`<TARGET_DATABASE>.main.flight_tracker` has one row per table. 
+Get feedback from the user about whether or not a schedule is desired and what it should be.
+
+## How it works
+
+`flight.py` runs a fixed sequence:
+
+1. **Connect.** Set `motherduck_host` if `MOTHERDUCK_HOST` given, `duckdb.connect("md:")`.
+2. **Attach Postgres read-only.** Export `pg_*` to libpq env vars, `INSTALL`/`LOAD postgres`, `ATTACH '' AS pg (TYPE postgres, READ_ONLY)`. `READ_ONLY` lets the extension parallelize reads; the empty connection string keeps the password in env, never in SQL.
+3. **Ensure target.** `CREATE DATABASE IF NOT EXISTS` plus creating the `main.flight_tracker` audit table.
+4. **Discover base tables** List base tables (`information_schema.tables WHERE table_type = 'BASE TABLE'` via `postgres_query`), keep those passing the gates.
+5. **Load each table.** Pre-create schemas, then per table run `CREATE OR REPLACE ... AS SELECT *` under a tenacity retry (jittered exponential backoff, transient errors). Log a `flight_tracker` row on success; on failure after retries, log and continue (per-table isolation). Exit non-zero if anything failed.
+
+## Caveats
+
+- **Full refresh re-reads the whole table every run.** Cost scales with table
+  size, not change volume. Updates and deletes are reflected, but a table
+  **dropped** from the source is NOT dropped from the target — remove it yourself
+  or recreate the target database. For very large/slowly-changing tables, an
+  incremental pattern is cheaper.
+- **The upload is single threaded and sequential by design.** Testing a ~90M-row database showed 
+  no improvement when parallelizing the load of multiple large tables.
+  Testing also showed that adjusting DuckDB `threads`, `pg_pages_per_task`,
+  `pg_connection_limit`, `pg_pool_max_connections`, and using multiple Python threads all
+  leave total time unchanged - hence the simple sequential loop. 
+  If performance is critical, consider the added dependency of an AWS S3 bucket in your MotherDuck region and 
+  staging Postgres data in Parquet in S3 and ingest server-side 
+  (`read_parquet('s3://…')` runs in the MotherDuck duckling).
+  This Flight avoids the dependency on an S3 bucket to keep things simpler.
+- **`SELECT *` relies on the extension's type mapping.** Exotic Postgres types
+  (custom enums, ranges, `hstore`, composite arrays) may surface as `VARCHAR` or
+  error — exclude such tables or fork `load_table` to project columns.
+- **Base tables only.** Discovery filters `table_type = 'BASE TABLE'`; views,
+  materialized views, and foreign tables are skipped by design.
+- **Client-side extension.** The Postgres scan runs in the Flight container and rows upload to MotherDuck from there.
+- **Old tables are not dropped.** The target database is not cleared out at the start of the run, 
+  so old tables can persist. A separate command would be required to clear out the target database.
+
+## Security
+
+- **Connection in a secret, never config or SQL.** The password comes from a
+  `TYPE flights` secret and reaches the extension via libpq env vars
+  (`PGPASSWORD`, …) — never in a SQL statement or log. Plain Flight `config` is
+  not treated as sensitive.
+- **Read-only source.** Attached `READ_ONLY`, so the Flight can never write back.
+- **Quoted identifiers.** `TARGET_DATABASE` and discovered schema/table names flow
+  into `CREATE`/`SELECT` (not parameterizable) via `quote_ident()`. This prevents SQL injection.
+
+## Learn more
+
+- Flight mechanics (create, run, schedule, secrets): MCP `get_flight_guide`.
+- DuckDB `postgres` extension: [duckdb.org/docs](https://duckdb.org/docs/stable/core_extensions/postgres).
+- Deeper MotherDuck/DuckDB questions: MCP `ask_docs_question`.
+- Files: [`flight.py`](flight.py) (the Flight source), [`requirements.txt`](requirements.txt) (`duckdb` plus `tenacity` for retry/backoff; the `postgres` extension is a runtime core extension, not a pip package).

--- a/flight-plans/flight-postgres-ingest/flight.py
+++ b/flight-plans/flight-postgres-ingest/flight.py
@@ -1,0 +1,304 @@
+"""
+Postgres -> MotherDuck batch ELT flight
+
+Mirrors PostgreSQL base tables into a MotherDuck database using the DuckDB postgres
+extension. Each table is moved by a single streaming SQL statement:
+
+    CREATE OR REPLACE TABLE <target>."<schema>"."<table>" AS SELECT * FROM pg."<schema>"."<table>";
+
+That statement is the entire load. It is:
+    ATOMIC (CREATE OR REPLACE swaps in one step)
+    IDEMPOTENT (re-running fully replaces)
+    STREAMING (DuckDB pipelines the scan into the write, bounded memory)
+
+Per-table logging lands in  `<target>.main.flight_tracker`.
+
+Inputs
+------
+Note that inputs are case sensitive (use uppercase).
+
+Secret `pg` (TYPE flights) -> Postgres connection params: 
+    Required: `HOST`, `DATABASE`, `USER`, `PASSWORD`
+    Optional: `PORT`, `SSLMODE`
+    Example:
+        CREATE SECRET pg IN motherduck (
+            TYPE flights,
+            PARAMS MAP {
+                'HOST':     '<your-postgres-host>',
+                'PORT':     '5432',
+                'DATABASE': '<your_database>',
+                'USER':     '<YOUR_USER>',
+                'PASSWORD': '<YOUR_PASSWORD>',
+                'SSLMODE':  'require'
+            }
+        );
+Config (non-secret env vars):
+    MOTHERDUCK_HOST  - staging host; exported as `motherduck_host` before connect.
+    TARGET_DATABASE  - MotherDuck database to write into (default: postgres_ingest).
+    INCLUDED_SCHEMAS / EXCLUDED_SCHEMAS  - comma-separated schema names.
+    INCLUDED_TABLES  / EXCLUDED_TABLES   - comma-separated, fully qualified schema.table.
+    MAX_RETRIES (5) 
+    RETRY_BASE_SECONDS (2)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+
+import duckdb
+from tenacity import (
+    Retrying,
+    stop_after_attempt,
+    wait_exponential,
+    wait_random,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("pg2md")
+
+# PostgreSQL system schemas that are never mirrored. 
+SYSTEM_SCHEMAS = {"information_schema", "pg_catalog", "pg_toast"}
+
+# Postgres connection params from the flight secret. 
+# The secret injects each as `<secret_name>_<KEY>`
+PG_PARAMS = (
+    ("HOST", "PGHOST", None, True),
+    ("PORT", "PGPORT", "5432", False),
+    ("DATABASE", "PGDATABASE", None, True),
+    ("USER", "PGUSER", None, True),
+    ("PASSWORD", "PGPASSWORD", None, True),
+    ("SSLMODE", "PGSSLMODE", "prefer", False),
+)
+
+# Local DuckDB catalog name the source Postgres database is ATTACHed as. Referenced by
+# attach_postgres(), discover_base_tables(), and load_table() -- one source of truth.
+PG_ALIAS = "pg"
+
+
+# --------------------------------------------------------------------------- #
+# Small SQL / env helpers
+# --------------------------------------------------------------------------- #
+def quote_ident(ident: str) -> str:
+    """Build safe SQL by quoting an identifier the way DuckDB/Postgres expect, so
+    names with special characters or reserved words are handled correctly. Pass any
+    identifier string and use the returned double-quoted, escaped form in SQL text."""
+    return '"' + ident.replace('"', '""') + '"'
+
+
+def csv_set(name: str) -> frozenset[str]:
+    """Turn a comma-separated env var into a clean set for membership filtering, which
+    the schema/table selection gates rely on. Pass the env var name and receive a set
+    of trimmed, non-empty values (empty set if unset)."""
+    raw = os.environ.get(name, "") or ""
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+# --------------------------------------------------------------------------- #
+# Table selection
+# --------------------------------------------------------------------------- #
+def is_selected(
+    schema: str,
+    table: str,
+    included_schemas: frozenset[str],
+    excluded_schemas: frozenset[str],
+    included_tables: frozenset[str],
+    excluded_tables: frozenset[str],
+) -> bool:
+    """Decide whether a discovered base table is mirrored, applying the two include/exclude
+    gates where exclude always wins and system schemas are excluded."""
+    fqtn = f"{schema}.{table}"
+    if schema in SYSTEM_SCHEMAS or schema.startswith("pg_temp") or schema.startswith("pg_toast"):
+        return False
+    if included_schemas and schema not in included_schemas:
+        return False
+    if schema in excluded_schemas:
+        return False
+    if included_tables and fqtn not in included_tables:
+        return False
+    if fqtn in excluded_tables:
+        return False
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Connection + setup
+# --------------------------------------------------------------------------- #
+def connect_motherduck() -> duckdb.DuckDBPyConnection:
+    """Open the MotherDuck connection that backs the whole flight, targeting the configured
+    host when one is set."""
+    host = os.environ.get("MOTHERDUCK_HOST")
+    if host:
+        os.environ["motherduck_host"] = host
+        log.info("Targeting MotherDuck host: %s", host)
+    else:
+        log.info("MOTHERDUCK_HOST not set; using runtime default MotherDuck host")
+    return duckdb.connect("md:")
+
+
+def attach_postgres(con: duckdb.DuckDBPyConnection, secret_name: str) -> None:
+    """Wire up the read-only Postgres source so tables can be streamed out, keeping the
+    password out of SQL by passing credentials through libpq env vars. 
+    ATTACHes READ_ONLY as `pg`."""
+    for key, libpq_var, default, required in PG_PARAMS:
+        env_var = f"{secret_name}_{key}"
+        value = os.environ.get(env_var, default)
+        if value is None:
+            if required:
+                raise RuntimeError(f"Required Postgres secret env var {env_var!r} is not set")
+            continue
+        os.environ[libpq_var] = str(value)
+
+    con.execute("INSTALL postgres")
+    con.execute("LOAD postgres")
+    con.execute(f"ATTACH '' AS {PG_ALIAS} (TYPE postgres, READ_ONLY)")
+    log.info(
+        "Attached Postgres %s:%s/%s (read-only, sslmode=%s)",
+        os.environ["PGHOST"], os.environ["PGPORT"],
+        os.environ["PGDATABASE"], os.environ["PGSSLMODE"],
+    )
+
+
+def ensure_target(con: duckdb.DuckDBPyConnection, target_db: str) -> None:
+    """Create the target database and the audit logging table up front."""
+    target = quote_ident(target_db)
+    con.execute(f"CREATE DATABASE IF NOT EXISTS {target}")
+    con.execute(
+        f"CREATE TABLE IF NOT EXISTS {target}.main.flight_tracker ("
+        "  run_id               VARCHAR,"
+        "  flight_secret_name   VARCHAR,"
+        "  source_schema        VARCHAR,"
+        "  source_table         VARCHAR,"
+        "  destination_database VARCHAR,"
+        "  destination_schema   VARCHAR,"
+        "  destination_table    VARCHAR,"
+        "  rows_loaded          BIGINT,"
+        "  attempts             INTEGER,"
+        "  started_at           TIMESTAMP,"
+        "  finished_at          TIMESTAMP,"
+        "  update_ts            TIMESTAMP"
+        ")"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Discovery + per-table load
+# --------------------------------------------------------------------------- #
+def discover_base_tables(con: duckdb.DuckDBPyConnection) -> list[tuple[str, str]]:
+    """List the candidate source tables to iterate on"""
+    rows = con.execute(
+        f"SELECT table_schema, table_name FROM postgres_query('{PG_ALIAS}', "
+        "'SELECT table_schema, table_name FROM information_schema.tables "
+        "WHERE table_type = ''BASE TABLE''') "
+        "ORDER BY table_schema, table_name"
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+def load_table(con: duckdb.DuckDBPyConnection, target_db: str, schema: str, table: str) -> int:
+    """Perform the entire data movement for one table as a single atomic, idempotent,
+    streaming CTAS. returns the row count the CTAS reports as inserted."""
+    tgt_table = f"{quote_ident(target_db)}.{quote_ident(schema)}.{quote_ident(table)}"
+    src_table = f"{PG_ALIAS}.{quote_ident(schema)}.{quote_ident(table)}"
+    return con.execute(f"CREATE OR REPLACE TABLE {tgt_table} AS SELECT * FROM {src_table}").fetchone()[0]
+
+
+def record_success(
+    con: duckdb.DuckDBPyConnection, target_db: str, run_id: str, secret_name: str,
+    schema: str, table: str, rows_loaded: int, attempts: int,
+    started_at: datetime, finished_at: datetime, update_ts: datetime,
+) -> None:
+    """After success, append a row to the audit table"""
+    con.execute(
+        f"INSERT INTO {quote_ident(target_db)}.main.flight_tracker "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [run_id, secret_name, schema, table, target_db, schema, table,
+         rows_loaded, attempts, started_at, finished_at, update_ts],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def main() -> None:
+    """Orchestrate the full-refresh ELT: connect, attach, discover, then load each
+    table sequentially with per-table retries/isolation and record results."""
+    # Run config, read once from the environment and referenced as needed below.
+    RUN_ID = str(uuid.uuid4())
+    TARGET_DB = os.environ.get("TARGET_DATABASE", "postgres_ingest")
+    MAX_RETRIES = int(os.environ.get("MAX_RETRIES", "5"))
+    RETRY_BASE_SECONDS = float(os.environ.get("RETRY_BASE_SECONDS", "2"))
+    INCLUDED_SCHEMAS = csv_set("INCLUDED_SCHEMAS")
+    EXCLUDED_SCHEMAS = csv_set("EXCLUDED_SCHEMAS")
+    INCLUDED_TABLES = csv_set("INCLUDED_TABLES")
+    EXCLUDED_TABLES = csv_set("EXCLUDED_TABLES")
+    # MotherDuck Flights secret holding the Postgres connection; its params arrive as
+    # <SECRET_NAME>_HOST, <SECRET_NAME>_PORT, ... Change it to point at another secret.
+    SECRET_NAME = "pg"
+
+    log.info("Run %s -> target %r", RUN_ID, TARGET_DB)
+
+    con = connect_motherduck()
+    attach_postgres(con, SECRET_NAME)
+    ensure_target(con, TARGET_DB)
+
+    all_tables = discover_base_tables(con)
+    selected = [
+        (s, t) for (s, t) in all_tables
+        if is_selected(s, t, INCLUDED_SCHEMAS, EXCLUDED_SCHEMAS, INCLUDED_TABLES, EXCLUDED_TABLES)
+    ]
+    log.info("Discovered %d base table(s); %d selected after filters", len(all_tables), len(selected))
+
+    if not selected:
+        log.warning("No tables selected - nothing to do.")
+        return
+
+    # Pre-create the target schemas (mirroring source schema names) once.
+    for sch in sorted({s for (s, _) in selected}):
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(TARGET_DB)}.{quote_ident(sch)}")
+
+    started_all = datetime.now(timezone.utc)
+    failed: list[str] = []
+    succeeded = 0
+    rows_total = 0
+
+    for schema, table in selected:
+        fqtn = f"{schema}.{table}"
+        started = datetime.now(timezone.utc)
+        retryer = Retrying(
+            stop=stop_after_attempt(MAX_RETRIES),
+            wait=wait_exponential(multiplier=RETRY_BASE_SECONDS, max=60) + wait_random(0, 1),
+            reraise=True,
+        )
+        try:
+            rows = retryer(load_table, con, TARGET_DB, schema, table)
+            attempts = retryer.statistics.get("attempt_number", 1)
+            finished = datetime.now(timezone.utc)
+            record_success(con, TARGET_DB, RUN_ID, SECRET_NAME, schema, table, rows,
+                           attempts, started, finished, datetime.now(timezone.utc))
+            succeeded += 1
+            rows_total += rows
+            log.info("OK   %-50s %12d rows (attempts=%d)", fqtn, rows, attempts)
+        except Exception as exc:  # noqa: BLE001 - per-table isolation is intentional
+            attempts = retryer.statistics.get("attempt_number", 1)
+            failed.append(fqtn)
+            log.error("FAIL %-50s (attempts=%d) %s: %s", fqtn, attempts, type(exc).__name__, exc)
+
+    total_seconds = (datetime.now(timezone.utc) - started_all).total_seconds()
+    log.info("Summary: %d succeeded, %d failed, %d rows in %.1fs (run %s)",
+             succeeded, len(failed), rows_total, total_seconds, RUN_ID)
+
+    if failed:
+        log.error("Failed tables: %s", ", ".join(failed))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/flight-plans/flight-postgres-ingest/requirements.txt
+++ b/flight-plans/flight-postgres-ingest/requirements.txt
@@ -1,0 +1,6 @@
+duckdb==1.5.2
+# `tenacity` provides the jittered exponential-backoff retry wrapper around each
+# per-table load. The `postgres` extension is a DuckDB CORE extension loaded at
+# runtime (INSTALL postgres; LOAD postgres), not a pip package, so it is not
+# listed here; there is no pip Postgres client dependency.
+tenacity==9.0.0


### PR DESCRIPTION
## What

Adds a new Flight Plan template: **`flight-plans/flight-postgres-ingest`** — a single-file MotherDuck Flight that mirrors PostgreSQL base tables into a MotherDuck database.

The load pattern is a **full-refresh, atomic swap per table**: each run attaches Postgres read-only via the DuckDB `postgres` extension, discovers in-scope base tables, and moves each with one streaming statement:

```sql
CREATE OR REPLACE TABLE <target>."<schema>"."<table>" AS SELECT * FROM pg."<schema>"."<table>"
```

That statement *is* the whole load — atomic (swaps in one step), idempotent (no watermark to drift), and streaming (flat memory even on large tables). Python only orchestrates discovery, retries, and per-table audit logging.

## Highlights

- **Config-driven selection.** Mirrors every non-system base table by default; narrow with `INCLUDED_SCHEMAS` / `EXCLUDED_SCHEMAS` / `INCLUDED_TABLES` / `EXCLUDED_TABLES` (exclude always wins). No per-table config blob and no code edits required for the common case.
- **Connection in a Flights secret.** Postgres connection (incl. password) comes from a `TYPE flights` secret named `pg`, injected as `pg_*` env vars and passed to the extension via libpq env — never in SQL or logs.
- **Read-only, retried, audited.** Source attached `READ_ONLY`; each table load is wrapped in a tenacity jittered exponential backoff retry; a `main.flight_tracker` row is written per successful table; the run exits non-zero if any table fails after retries (per-table isolation).
- **Honest caveats.** Documents full-refresh cost, single-stream upload behavior (a parameter sweep on a ~90M-row source showed `threads` / `pg_pages_per_task` / connection-pool knobs / Python concurrency don't change total time), `SELECT *` type-mapping limits, and that source-dropped tables are not auto-removed from the target.

## Files

- `flight-plans/flight-postgres-ingest/flight.py` — the Flight source
- `flight-plans/flight-postgres-ingest/requirements.txt` — `duckdb` + `tenacity`
- `flight-plans/flight-postgres-ingest/README.md` — front matter + usage, deploy, how-it-works, caveats, security

## Validation

- `uv run scripts/build-catalog.py` → `Validated 28 catalog item(s)` (front matter conforms: `type: template`, `features: [flights]`, lowercase-slug `tags: [postgres, ingest, migrate]`).
- `python3 -m py_compile flight.py` → compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
