### PR TITLE
Drop access_token_name from Flight READMEs, prefer SQL surface over MCP tools

### DIFF
--- a/.agents/skills/motherduck-examples/SKILL.md
+++ b/.agents/skills/motherduck-examples/SKILL.md
@@ -22,10 +22,9 @@ There are two entry families:
   section, but they still live at the repo root.
 - `flight-plans/`: reusable, single-file Flight templates (`type: template`) that
   an agent adapts and deploys. This directory is purely for template-style Flight
-  files, not concrete examples. It currently holds `flight-scheduled-s3-ingest`
-  (scheduled, incremental partitioned S3 Parquet ingest), `flight-dlt-ingest`
-  (a dlt pipeline into MotherDuck), and `flight-provision-user-databases` (an
-  admin Flight that provisions per-user databases and shares).
+  files, not concrete examples. See the directory for the current set (S3, dlt,
+  Postgres, Snowflake, and BigQuery ingests, freshness alerts, user-database
+  provisioning, Dive usage metrics, ...).
 
 Keep all examples at the repo root, even flight-capable ones. Do not create an
 `examples/` wrapper folder, and do not move concrete examples into `flight-plans/`.
@@ -34,8 +33,16 @@ Keep all examples at the repo root, even flight-capable ones. Do not create an
 
 - README YAML front matter is the catalog metadata source of truth.
 - Flight Plans are non-deterministic plans an agent adapts after asking the user
-  a few questions; deploy them via the MotherDuck MCP Flight tools, not
-  checked-in create-flight SQL. (This rule is about `flight-plans/` templates.)
+  a few questions; their READMEs describe deployment through the Flight SQL
+  surface (`MD_CREATE_FLIGHT`, `MD_RUN_FLIGHT`, `MD_FLIGHTS()`), and no
+  create-flight SQL is checked in. (This rule is about `flight-plans/` templates.)
+- The Flight runtime attaches a MotherDuck token automatically and injects it as
+  `MOTHERDUCK_TOKEN` at run time. Do not document an `access_token_name`
+  argument in READMEs.
+- READMEs must work for humans and for agents on any client: name MCP tools
+  (`get_flight_guide`, `create_flight`, `query_rw`, ...) only in `## Caveats` or
+  `## Learn more`. In every other section reference the SQL surface
+  (`MD_CREATE_FLIGHT`, `MD_RUN_FLIGHT`, `CREATE SECRET`, ...) or the UI instead.
 - A concrete example that deploys as a Flight may ship a deploy script that
   calls the Flight SQL surface (`MD_CREATE_FLIGHT` / `MD_UPDATE_FLIGHT`,
   resolving by name via `MD_FLIGHTS()`), the same way a Dive example ships a
@@ -113,7 +120,9 @@ Use this structure:
    `### Deploy as a Flight` subsection under `## Run it`.
 6. `## How it works / Learn more`: link to extra files in the folder and point
    to MCP guides such as `get_flight_guide`, `get_dive_guide`, or
-   `ask_docs_question`.
+   `ask_docs_question`. This and `## Caveats` are the only places where MCP tool
+   names belong; every other section uses the SQL surface (`MD_CREATE_FLIGHT`,
+   `MD_RUN_FLIGHT`) or the UI so the README works on any client.
 
 This structure is a frame, not a cap. Add sections when the example has valuable
 content that does not fit, for example `## Caveats` for footguns, limitations,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,18 @@ or the starter script.
   commit a generated `catalog.json` unless the user explicitly changes that
   decision.
 - `flight-plans/` is only for reusable, single-file Flight templates
-  (`type: template`). It currently holds `flight-scheduled-s3-ingest`,
-  `flight-dlt-ingest`, and `flight-provision-user-databases`.
+  (`type: template`); see that directory for the current set.
 - All concrete examples live at the repo root, including flight-capable ones that
   carry `features: [flights]` and a "Deploy as a Flight" section. Do not move them
   under `flight-plans/` or a new `examples/` folder.
 - Flight Plan templates (`flight-plans/`) are non-deterministic agent plans:
-  deploy them via README prose and the MotherDuck MCP Flight tools, not
-  checked-in create-flight SQL.
+  deploy them via README prose and the Flight SQL surface (`MD_CREATE_FLIGHT`,
+  `MD_RUN_FLIGHT`); no create-flight SQL is checked in.
+- The Flight runtime attaches a MotherDuck token automatically (injected as
+  `MOTHERDUCK_TOKEN`); never document an `access_token_name` argument in READMEs.
+- READMEs serve humans and agents on any client: MCP tool names
+  (`get_flight_guide`, `ask_docs_question`, ...) belong only in Caveats or
+  Learn more sections; everywhere else reference SQL functions or the UI.
 - A concrete example that deploys as a Flight may ship a deploy script that calls
   the Flight SQL surface (`MD_CREATE_FLIGHT` / `MD_UPDATE_FLIGHT`, resolving by
   name via `MD_FLIGHTS()`) — the same shape as a Dive example's `deploy-dive.sh`.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ curl -fsSL https://get.motherduck.com | bash -s dbt-ingestion-s3
 ## Flight templates
 
 Reusable, single-file Flights under [`flight-plans/`](flight-plans)
-(`type: template`) that an agent adapts and deploys. Deploy them with the
-MotherDuck MCP server (`get_flight_guide`, then `create_flight`); each README
-lists the config knobs to set.
+(`type: template`) that an agent adapts and deploys. Deploy them with the Flight
+SQL functions (`MD_CREATE_FLIGHT`, then `MD_RUN_FLIGHT`); each README lists the
+config knobs to set. The runtime attaches a MotherDuck token automatically and
+injects it as `MOTHERDUCK_TOKEN`.
 
 - [flight-scheduled-s3-ingest](flight-plans/flight-scheduled-s3-ingest) - Refresh a MotherDuck table from Hive-partitioned S3 Parquet on a schedule, reading only the partition that changes.
 - [flight-dlt-ingest](flight-plans/flight-dlt-ingest) - Run a dlt pipeline into MotherDuck on a schedule, with Parquet loader files and schema evolution.

--- a/flight-plans/flight-bigquery-ingest/README.md
+++ b/flight-plans/flight-bigquery-ingest/README.md
@@ -98,9 +98,8 @@ secret**. The simplest way is the MotherDuck UI: open
 [Settings > Secrets](https://app.motherduck.com/settings/secrets), add a secret of
 type **Flights**, and give it a `GOOGLE_APPLICATION_CREDENTIALS_JSON` parameter
 whose value is the entire JSON key as one string. If you would rather use SQL, you
-can create the same secret from the DuckDB client or any SQL connection (the
-read-only `query` MCP tool rejects `CREATE SECRET`, so use `query_rw` or a direct
-connection):
+can create the same secret from the DuckDB client or any write-enabled SQL
+connection (read-only connections reject `CREATE SECRET`):
 
 ```sql
 CREATE SECRET gcp_creds IN motherduck (
@@ -119,26 +118,28 @@ env var ending in `_GOOGLE_APPLICATION_CREDENTIALS_JSON`, then writes the JSON t
 a temp file and points `GOOGLE_APPLICATION_CREDENTIALS` at it. The secret name you
 choose does not matter.
 
-Then deploy with the MotherDuck MCP server rather than checked-in SQL. Call
-`get_flight_guide` first for the exact tool arguments, then `create_flight` with:
+Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL
+is checked in; adapt the arguments to your situation), passing:
 
+- `name`: a Flight name, for example `bigquery_ingest`
 - `source_code`: the contents of [`flight.py`](flight.py), with the USER-EDIT
   BLOCKS edited to your query and destination
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
-- `access_token_name`: a service account token that can write the destination
-  (list tokens with the `md_access_tokens()` table function); the runtime
-  injects its value as `MOTHERDUCK_TOKEN`
 - `flight_secret_names`: `["gcp_creds"]` so the SA JSON is injected (as
   `gcp_creds_GOOGLE_APPLICATION_CREDENTIALS_JSON`; `flight.py` resolves it)
 - `config`: `GCP_PROJECT_ID` (and optionally `BIGQUERY_DEST_DB`, `EVENT_SOURCE`).
   The billing project is not a secret, so it belongs in config. The SA JSON does
   NOT: keep it in the secret above.
 
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed.
+
 Create the Flight without a schedule first, trigger one manual run with
-`run_flight`, and confirm it loads the cold-start partition. Then add a schedule
-(for example `0 6 * * *`, daily at 06:00 UTC) by updating the Flight's
-`schedule_cron`. Schedule updates are metadata-only and do not create a new
-Flight version. For a one-off backfill, set `start_dt`/`end_dt` (or `target_dt`)
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`), and confirm it loads the cold-start partition. Then
+add a schedule (for example `0 6 * * *`, daily at 06:00 UTC) by updating the
+Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates are
+metadata-only and do not create a new Flight version. For a one-off backfill, set `start_dt`/`end_dt` (or `target_dt`)
 in the run config.
 
 ## How it works

--- a/flight-plans/flight-dive-usage-metrics/README.md
+++ b/flight-plans/flight-dive-usage-metrics/README.md
@@ -94,20 +94,24 @@ LIMIT 20;
 
 ### Deploy as a Flight
 
-Deploy with the MotherDuck MCP server rather than checked-in SQL. Call
-`get_flight_guide` first for the exact tool arguments, then `create_flight` with:
+Create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments to your situation), passing:
 
+- `name`: a Flight name, for example `dive_usage_metrics`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
-- `access_token_name`: a service account token that can read the Dives you want
-  counted and write `TARGET_DATABASE` (list tokens with the `md_access_tokens()`
-  table function); the runtime injects its value as `MOTHERDUCK_TOKEN`
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
-Create the Flight without a schedule, trigger one manual run with `run_flight`,
-and read the run logs and the `_latest` view to confirm the metrics look right.
-Then add a schedule by updating the Flight's `schedule_cron`. A daily run
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed. The run can only count
+Dives that token can read, so deploy from an account that sees them.
+
+Create the Flight without a schedule, trigger one manual run with
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`), and read the run logs and the `_latest` view to
+confirm the metrics look right. Then add a schedule by updating the Flight's
+`schedule_cron` with `MD_UPDATE_FLIGHT`. A daily run
 (`0 6 * * *`) or weekly run (`0 6 * * 1`) is a reasonable cadence, since Dive
 source SQL changes slowly. Schedule updates are metadata-only and do not create a
 new Flight version.
@@ -225,8 +229,8 @@ LIMIT 20;
   Rows are written in chunked bulk multi-row `INSERT`s.
 - **Read-only against Dives.** The Flight only reads Dives (`MD_LIST_DIVES`,
   `MD_GET_DIVE`) and writes solely to `TARGET_DATABASE` (the usage, dependency,
-  co-occurrence, and join-key tables). Scope the token accordingly: read access to
-  the Dives you want counted, write access to the target database.
+  co-occurrence, and join-key tables). The automatically attached token needs read
+  access to the Dives you want counted and write access to the target database.
 
 ## Learn more
 

--- a/flight-plans/flight-dlt-ingest/README.md
+++ b/flight-plans/flight-dlt-ingest/README.md
@@ -72,22 +72,25 @@ default inline, for example `GITHUB_REPOS=duckdb/duckdb uv run --with-requiremen
 
 ### Deploy as a Flight
 
-Deploy with the MotherDuck MCP server rather than checked-in SQL. Call
-`get_flight_guide` first for the exact tool arguments, then `create_flight` with:
+Create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments to your situation), passing:
 
+- `name`: a Flight name, for example `dlt_ingest`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
-- `access_token_name`: a service account token name (list them with the
-  `md_access_tokens()` table function); the runtime injects its value as
-  `MOTHERDUCK_TOKEN`
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed.
+
 Create the Flight without a schedule first, trigger one manual run with
-`run_flight`, and confirm it succeeds and the dlt tables and ledger row appear.
-Once the manual run is green, add a daily schedule (`15 7 * * *`, 07:15 UTC, is a
-reasonable default) by updating the Flight's `schedule_cron`. Schedule updates are
-metadata-only and do not create a new Flight version.
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`), and confirm it succeeds and the dlt tables and ledger
+row appear. Once the manual run is green, add a daily schedule (`15 7 * * *`,
+07:15 UTC, is a reasonable default) by updating the Flight's `schedule_cron` with
+`MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
+Flight version.
 
 ## How it works
 
@@ -139,8 +142,8 @@ direct inserts are fine.
   [Settings > Secrets](https://app.motherduck.com/settings/secrets), or
   `CREATE SECRET ... (TYPE flights, ...)` from the DuckDB client), which the
   runtime injects as env vars you read with `os.environ`.
-- **Keep the token out of config.** Select a token on the Flight so
-  `MOTHERDUCK_TOKEN` is injected at runtime; do not place it in `config`.
+- **Keep the token out of config.** The runtime attaches a MotherDuck token and
+  injects it as `MOTHERDUCK_TOKEN`; never place a token in `config`.
 
 ## Security
 

--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -109,9 +109,8 @@ Store the webhook URL from [Create the Slack webhook](#create-the-slack-webhook)
 a MotherDuck **Flights secret**. The simplest way is the MotherDuck UI: open
 [Settings > Secrets](https://app.motherduck.com/settings/secrets), add a secret of
 type **Flights**, and give it a `SLACK_WEBHOOK_URL` parameter. If you would rather
-use SQL, you can create the same secret from the DuckDB client or any SQL
-connection (the read-only `query` MCP tool rejects `CREATE SECRET`, so use
-`query_rw` or a direct connection):
+use SQL, you can create the same secret from the DuckDB client or any
+write-enabled SQL connection (read-only connections reject `CREATE SECRET`):
 
 ```sql
 CREATE SECRET freshness_slack IN motherduck (
@@ -127,24 +126,26 @@ the unquoted secret name into the prefix.) `flight.py` handles this: it reads
 `SLACK_WEBHOOK_URL` for local runs and otherwise picks up any env var ending in
 `_SLACK_WEBHOOK_URL`, so the secret name you choose does not matter.
 
-Then deploy with the MotherDuck MCP server rather than checked-in SQL. Call
-`get_flight_guide` first for the exact tool arguments, then `create_flight` with:
+Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL
+is checked in; adapt the arguments to your situation), passing:
 
+- `name`: a Flight name, for example `freshness_alert`
 - `source_code`: the contents of [`flight.py`](flight.py), with `CHECKS` edited to your tables
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
-- `access_token_name`: a service account token that can read the checked tables
-  and write `RESULTS_TABLE` (list tokens with the `md_access_tokens()` table
-  function); the runtime injects its value as `MOTHERDUCK_TOKEN`
 - `flight_secret_names`: `["freshness_slack"]` so the webhook is injected (as
   `freshness_slack_SLACK_WEBHOOK_URL`; `flight.py` resolves it)
 
-No `config` is needed: every knob lives in the code.
+No `config` is needed: every knob lives in the code. A MotherDuck token is
+attached to the Flight automatically and injected at run time as
+`MOTHERDUCK_TOKEN`; no token argument is needed.
 
 Create the Flight without a schedule first, trigger one manual run with
-`run_flight`, and confirm it succeeds and a Slack alert arrives. Then edit
-`CHECKS` to your real tables and add a schedule (for example `0 * * * *`, hourly)
-by updating the Flight's `schedule_cron`. Schedule updates are metadata-only and
-do not create a new Flight version.
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`), and confirm it succeeds and a Slack alert arrives.
+Then edit `CHECKS` to your real tables and add a schedule (for example
+`0 * * * *`, hourly) by updating the Flight's `schedule_cron` with
+`MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
+Flight version.
 
 ## How it works
 

--- a/flight-plans/flight-postgres-ingest/README.md
+++ b/flight-plans/flight-postgres-ingest/README.md
@@ -103,8 +103,8 @@ non-zero if any table failed after retries.
 
 First store the connection as a **Flights secret** named `pg` (UI:
 [Settings > Secrets](https://app.motherduck.com/settings/secrets), type
-**Flights**). Or via SQL from a write connection (the read-only `query` MCP tool
-rejects `CREATE SECRET`; use `query_rw` or a direct connection):
+**Flights**). Or via SQL from a write-enabled connection (read-only connections
+reject `CREATE SECRET`):
 
 ```sql
 CREATE SECRET pg IN motherduck (
@@ -120,16 +120,20 @@ CREATE SECRET pg IN motherduck (
 );
 ```
 
-Then deploy with the MotherDuck MCP server (not checked-in SQL). Call
-`get_flight_guide` first for exact tool arguments, then `create_flight` with:
+Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL
+is checked in; adapt the arguments to your situation), passing:
 
+- `name`: a Flight name, for example `postgres_ingest`
 - `source_code`: [`flight.py`](flight.py) (no edits for the default "mirror everything non-system")
 - `requirements_txt`: [`requirements.txt`](requirements.txt)
-- `access_token_name`: a token that can write `TARGET_DATABASE` (list via `md_access_tokens()`); injected as `MOTHERDUCK_TOKEN`
 - `flight_secret_names`: `["pg"]` so the Postgres connection is injected
 - `config`: at least `TARGET_DATABASE`, plus any `INCLUDED_*`/`EXCLUDED_*` scoping and `MOTHERDUCK_HOST` if non-default. The connection stays in the `pg` secret, never config.
 
-Create without a schedule, run once with `run_flight`, and confirm
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed.
+
+Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`), and confirm
 `<TARGET_DATABASE>.main.flight_tracker` has one row per table. 
 Get feedback from the user about whether or not a schedule is desired and what it should be.
 

--- a/flight-plans/flight-provision-user-databases/README.md
+++ b/flight-plans/flight-provision-user-databases/README.md
@@ -78,23 +78,27 @@ DRY_RUN=false uv run --with duckdb==1.5.2 flight.py
 
 ### Deploy as a Flight
 
-Deploy with the MotherDuck MCP server rather than checked-in SQL. Call
-`get_flight_guide` first for the exact tool arguments, then `create_flight` with:
+Create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments to your situation), passing:
 
+- `name`: a Flight name, for example `provision_user_databases`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
-- `access_token_name`: an admin or service account token name (list them with the
-  `md_access_tokens()` table function); the runtime injects its value as
-  `MOTHERDUCK_TOKEN`
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
-Create the Flight without a schedule, trigger one manual run with `run_flight`
-while `DRY_RUN` is `true`, and read the ledger and run logs to confirm the plan.
-Then point `USERS_TABLE` at real usernames (or replace the seeded demo rows), set
-`DRY_RUN=false`, and run again to provision. Add a schedule by updating the
-Flight's `schedule_cron` only once you trust the control table; schedule updates
-are metadata-only and do not create a new Flight version.
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed. This Flight creates
+databases and shares, so deploy it from an account allowed to do both.
+
+Create the Flight without a schedule, trigger one manual run with
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`) while `DRY_RUN` is `true`, and read the ledger and run
+logs to confirm the plan. Then point `USERS_TABLE` at real usernames (or replace
+the seeded demo rows), set `DRY_RUN=false`, and run again to provision. Add a
+schedule by updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT` only
+once you trust the control table; schedule updates are metadata-only and do not
+create a new Flight version.
 
 ## How it works
 

--- a/flight-plans/flight-scheduled-s3-ingest/README.md
+++ b/flight-plans/flight-scheduled-s3-ingest/README.md
@@ -72,23 +72,26 @@ backfill a year.
 
 ### Deploy as a Flight
 
-Deploy with the MotherDuck MCP server rather than checked-in SQL. Call
-`get_flight_guide` first for the exact tool arguments, then `create_flight` with:
+Create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments to your situation), passing:
 
+- `name`: a Flight name, for example `scheduled_s3_ingest`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
-- `access_token_name`: a service account token name (list them with the
-  `md_access_tokens()` table function); the runtime injects its value as
-  `MOTHERDUCK_TOKEN`
 - `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
   override (omit any you are keeping at default)
 
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed.
+
 Create the Flight without a schedule first, trigger one manual run with
-`run_flight`, and confirm it succeeds. Each run reads only `LOAD_PARTITION`, so
-the live partition stays fresh without touching the historical files. Once the
-manual run is green, add a daily schedule (the source updates daily; `30 6 * * *`,
-06:30 UTC, is a reasonable default) by updating the Flight's `schedule_cron`.
-Schedule updates are metadata-only and do not create a new Flight version.
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`), and confirm it succeeds. Each run reads only
+`LOAD_PARTITION`, so the live partition stays fresh without touching the
+historical files. Once the manual run is green, add a daily schedule (the source
+updates daily; `30 6 * * *`, 06:30 UTC, is a reasonable default) by updating the
+Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates are
+metadata-only and do not create a new Flight version.
 
 ## How it works
 

--- a/flight-plans/flight-snowflake-ingest/README.md
+++ b/flight-plans/flight-snowflake-ingest/README.md
@@ -113,8 +113,7 @@ way is the MotherDuck UI: open
 [Settings > Secrets](https://app.motherduck.com/settings/secrets), add a secret of
 type **Flights**, and give it `SNOWFLAKE_USER` and `SNOWFLAKE_PASSWORD` parameters.
 If you would rather use SQL, you can create the same secret from the DuckDB client
-or any SQL connection (the read-only `query` MCP tool rejects `CREATE SECRET`, so
-use `query_rw` or a direct connection):
+or any write-enabled SQL connection (read-only connections reject `CREATE SECRET`):
 
 ```sql
 CREATE SECRET snowflake_creds IN motherduck (
@@ -134,22 +133,24 @@ reads the bare `SNOWFLAKE_USER` / `SNOWFLAKE_PASSWORD` for local runs and otherw
 picks up any env var ending in `_SNOWFLAKE_USER` / `_SNOWFLAKE_PASSWORD`, so the
 secret name you choose does not matter.
 
-Then deploy with the MotherDuck MCP server rather than checked-in SQL. Call
-`get_flight_guide` first for the exact tool arguments, then `create_flight` with:
+Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL
+is checked in; adapt the arguments to your situation), passing:
 
+- `name`: a Flight name, for example `snowflake_ingest`
 - `source_code`: the contents of [`flight.py`](flight.py)
 - `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
-- `access_token_name`: a service account token that can write `TARGET_DB` (list
-  tokens with the `md_access_tokens()` table function); the runtime injects its
-  value as `MOTHERDUCK_TOKEN`
 - `config`: the non-secret knobs, for example
   `{"MODE": "discover", "SNOWFLAKE_ACCOUNT": "ab12345.eu-west-1", "SNOWFLAKE_WAREHOUSE": "your_wh", "SNOWFLAKE_DATABASE": "SOURCE_DB", "TARGET_DB": "flights_demo", "DRY_RUN": "true"}`
 - `flight_secret_names`: `["snowflake_creds"]` so the user and password are
   injected (as `snowflake_creds_SNOWFLAKE_USER` / `snowflake_creds_SNOWFLAKE_PASSWORD`;
   `flight.py` resolves them)
 
-Create the Flight with `MODE=discover`, trigger one manual run with `run_flight`,
-and confirm the inventory lands in MotherDuck. Curate `selected`, then run
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed.
+
+Create the Flight with `MODE=discover`, trigger one manual run with
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`), and confirm the inventory lands in MotherDuck. Curate `selected`, then run
 `MODE=move` with `DRY_RUN=false` (a config change, not a new Flight version) to
 copy. Schedule it only if you want a recurring refresh.
 

--- a/nba-box-scores/README.md
+++ b/nba-box-scores/README.md
@@ -99,9 +99,8 @@ this repo at `NBA_FLIGHT_REPO_BRANCH` (default `main`) and runs the entrypoint â
 so you only deploy for the **first** registration (or when the bootstrapper,
 token, schedule, config, or requirements change); **shipping new pipeline code
 afterwards is just a `git push`**. `nba_nightly` carries
-`schedule_cron = "0 16 * * *"`; `nba_backfill` is on-demand (`run_flight`). The
-MCP `create_flight` / `update_flight` tools are the agent-driven equivalent. See
-[`flight/README.md`](./flight/README.md) for details.
+`schedule_cron = "0 16 * * *"`; `nba_backfill` is on-demand (trigger it with
+`MD_RUN_FLIGHT`). See [`flight/README.md`](./flight/README.md) for details.
 
 To deploy the Dive, run [`dive/scripts/deploy-dive.sh`](./dive/scripts/deploy-dive.sh):
 it builds the bundle and resolves the Dive by title via `MD_LIST_DIVES()`,

--- a/nba-box-scores/flight/README.md
+++ b/nba-box-scores/flight/README.md
@@ -57,6 +57,6 @@ it clones this repo at `NBA_FLIGHT_REPO_BRANCH` (default `main`), `uv sync`s the
 package, and runs the entrypoint from the synced venv. So you only run the deploy
 command for the **first** registration (or when the bootstrapper, token,
 schedule, config, or requirements change) — **shipping new pipeline code
-afterwards is just a `git push`** to the branch the bootstrapper clones. The
-MotherDuck MCP `create_flight` / `update_flight` tools are the agent-driven
-equivalent if you'd rather not run the script.
+afterwards is just a `git push`** to the branch the bootstrapper clones. If
+you'd rather not run the script, call the same `MD_CREATE_FLIGHT` /
+`MD_UPDATE_FLIGHT` SQL functions from any MotherDuck connection.


### PR DESCRIPTION
The Flight runtime now attaches a MotherDuck token automatically (injected as `MOTHERDUCK_TOKEN`), so the `access_token_name` argument is removed from all eight flight-plan READMEs and replaced with a one-line note about the auto-attached token. Deploy sections now reference the Flight SQL functions (`MD_CREATE_FLIGHT`, `MD_RUN_FLIGHT`, `MD_UPDATE_FLIGHT`, `MD_FLIGHTS()`) instead of MCP tool names like `get_flight_guide`, which stay confined to Caveats and Learn more sections so READMEs serve humans and agents on any client; each deploy section also gained the required `name` argument. The root README and both nba-box-scores READMEs got the same treatment, and the secret-creation paragraphs now say "any write-enabled SQL connection" instead of naming `query_rw`. Both conventions are encoded as durable decisions in the motherduck-examples skill and AGENTS.md, where the stale three-item flight-plans enumerations are also fixed. The SQL function names and signatures were verified against a live MotherDuck connection, and catalog validation plus tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)