### PR TITLE
[codex] Reorder example README sections

### DIFF
--- a/.agents/skills/motherduck-examples/SKILL.md
+++ b/.agents/skills/motherduck-examples/SKILL.md
@@ -111,14 +111,20 @@ Use this structure:
 
 1. `# <title>` and a short paragraph explaining what the example does and which
    MotherDuck pattern it demonstrates.
-2. `## What you'll adjust`: a table of real knobs found in the code, with each
-   knob's purpose and example values/options.
+2. `## How it works`: the concrete pattern, architecture, or files that explain
+   what the example does before readers start changing values.
 3. `## Questions to answer`: the information needed before adapting the example
    (source, target database/schema, load pattern, schedule, credentials).
-4. `## Run it`: local commands and environment variables.
-5. For flight-capable entries (`features` includes `flights`), add a
-   `### Deploy as a Flight` subsection under `## Run it`.
-6. `## How it works / Learn more`: link to extra files in the folder and point
+4. `## Caveats`: footguns, limitations, and cases where the example is the wrong
+   tool.
+5. `## What you'll adjust`: a table of real knobs found in the code, with each
+   knob's purpose and example values/options.
+6. `## Run it`: local commands and environment variables. For flight-capable
+   entries (`features` includes `flights`), add a `### Deploy as a Flight`
+   subsection under `## Run it`.
+7. `## Security`: credential handling, SQL safety, access-control notes, and
+   other security-specific concerns when relevant.
+8. `## Learn more`: link to extra files in the folder and point
    to MCP guides such as `get_flight_guide`, `get_dive_guide`, or
    `ask_docs_question`. This and `## Caveats` are the only places where MCP tool
    names belong; every other section uses the SQL surface (`MD_CREATE_FLIGHT`,

--- a/README.md
+++ b/README.md
@@ -108,14 +108,20 @@ tags: [dbt]                     # curated lowercase slugs: significant third-par
 The body follows a consistent, skimmable structure:
 
 1. `# <title>` and one paragraph on what it is and the MotherDuck pattern it shows.
-2. `## What you'll adjust` - a table of the real knobs found in the code, each with
-   its purpose and options or an example value.
+2. `## How it works` - the concrete pattern, architecture, or files that explain
+   what the example does before readers start changing values.
 3. `## Questions to answer` - the inputs needed before adapting the example.
-4. `## Run it` - exact commands for the project's runtime (plus a
+4. `## Caveats` - footguns, limitations, and cases where the example is the
+   wrong tool.
+5. `## What you'll adjust` - a table of the real knobs found in the code, each
+   with its purpose and options or an example value.
+6. `## Run it` - exact commands for the project's runtime (plus a
    `### Deploy as a Flight` subsection for any flight-capable example).
-5. `## How it works / Learn more` - progressive disclosure: links to extra
-   in-folder files, and pointers to the MotherDuck MCP guides (`get_flight_guide`,
-   `get_dive_guide`) and `ask_docs_question` instead of duplicating them.
+7. `## Security` - credential handling, SQL safety, access-control notes, and
+   other security-specific concerns when relevant.
+8. `## Learn more` - progressive disclosure: links to extra in-folder files, and
+   pointers to the MotherDuck MCP guides (`get_flight_guide`, `get_dive_guide`)
+   and `ask_docs_question` instead of duplicating them.
 
 ## Authoring and validation
 

--- a/cloudflare-workers-duckoffee/README.md
+++ b/cloudflare-workers-duckoffee/README.md
@@ -95,13 +95,27 @@ ORDER BY 1
  └──────────────┘          └────────────────────────┘
 ```
 
-## Security
+## Questions to answer
 
-Sanitize input on every endpoint that accepts it:
+- Which MotherDuck share or database holds the analytics, and what is its share URI?
+- What is the schema: a locations table, a per-day fact table, and a top-N dimension, plus the column names to use in the three queries?
+- What region is the account in, so you set the right `MOTHERDUCK_HOST`?
+- What is the voting question and the candidate list (8 to 12 items, kebab-case `id` values)?
+- What lat/lon coordinates back each location and candidate city?
+- What brand palette, copy, and assets should the frontend use?
+- What Worker name and cache TTL do you want?
 
-1. Parameterize queries. Every route uses numbered parameters, e.g. `WHERE location_id = $1::BIGINT`, rather than string interpolation.
-2. Validate inputs. `days` is parsed as an integer and clamped to `[7, 365]`; `location_id` is parsed and rejected with a 400 if it is not a valid integer; `candidate_id` must be one of the 10 hardcoded candidates; `session_id` must be a string of at most 64 characters.
-3. Read-only warehouse workload. The Worker only issues `SELECT` statements against the attached share, so there is no path from user input to a MotherDuck write. Votes live entirely in the Durable Object.
+## Caveats
+
+- The share URI is interpolated into the `ATTACH` statement, not parameterized. `DUCKOFFEE_SHARE` is operator-controlled config in `wrangler.toml`, not user input, so keep it that way: do not wire it to a request parameter or you reintroduce SQL injection on the attach.
+- Do not put the token in `wrangler.toml`. `MOTHERDUCK_TOKEN` is a Wrangler secret (`wrangler secret put`) in production and lives in `.dev.vars` locally; `.dev.vars` should be gitignored. The `[vars]` block is for non-secret config (host, db, share) only.
+- `nodejs_compat` is required and fails silently if dropped. Remove the flag and the `pg` import breaks at runtime, not at build time. If you see module-resolution errors for `pg`, this is the first thing to check.
+- The Postgres host is region-specific. `pg.us-east-1-aws.motherduck.com` only works for accounts in that region. Point `MOTHERDUCK_HOST` at your own region's endpoint or connections will fail.
+- Sample-data cities have no coordinates. `duckoffee.locations` stores city names but no lat/lon, so any city missing from `CITY_COORDS` returns `lon: null, lat: null` and silently will not plot on the map. Add a coordinate entry for every location you query.
+- Candidate `id` is a permanent key. The `id` in `CANDIDATES` is the value stored in the Durable Object. Renaming it after votes exist orphans those votes under the old key, so pick a stable kebab-case `id` up front.
+- Each browser tab is a distinct voter. The session ID is `sessionStorage`-backed, so two tabs count as two voters, and clearing storage creates a fresh voter. This is fine for a demo, not a substitute for real auth.
+- One client per request. `withClient` opens and closes a `pg` connection per call rather than pooling; that is the simple, correct pattern for the Workers request model, but it is not a high-throughput connection pool.
+- Edge cache hides fresh data. The three SQL endpoints are cached for `DATA_CACHE_TTL_SECONDS` (15 minutes) via the Cloudflare cache, so updates to the share will not appear until the TTL expires. Lower it while developing if you expect the data to change.
 
 ## What you'll adjust
 
@@ -118,16 +132,6 @@ Sanitize input on every endpoint that accepts it:
 | `DATA_CACHE_TTL_SECONDS` (`src/index.ts`) | Edge cache TTL for the three SQL endpoints | `15 * 60` (15 minutes) |
 | `days` clamp in `handleSales` | Range and default for the daily series window | default 90, clamped to `[7, 365]` |
 | Brand colors / assets (`public/style.css`, `public/assets/`) | Look and feel of the SPA | CSS custom properties at top of `style.css`; swap SVGs in `public/assets/` |
-
-## Questions to answer
-
-- Which MotherDuck share or database holds the analytics, and what is its share URI?
-- What is the schema: a locations table, a per-day fact table, and a top-N dimension, plus the column names to use in the three queries?
-- What region is the account in, so you set the right `MOTHERDUCK_HOST`?
-- What is the voting question and the candidate list (8 to 12 items, kebab-case `id` values)?
-- What lat/lon coordinates back each location and candidate city?
-- What brand palette, copy, and assets should the frontend use?
-- What Worker name and cache TTL do you want?
 
 ## Run it
 
@@ -154,6 +158,14 @@ npx wrangler deploy
 
 The first deploy creates the `duckoffee-map` Worker, uploads `./public` through the `[assets]` binding, and provisions the `VoteTracker` Durable Object via the `[[migrations]]` entry (`new_sqlite_classes = ["VoteTracker"]`). Subsequent deploys just upload new code.
 
+## Security
+
+Sanitize input on every endpoint that accepts it:
+
+1. Parameterize queries. Every route uses numbered parameters, e.g. `WHERE location_id = $1::BIGINT`, rather than string interpolation.
+2. Validate inputs. `days` is parsed as an integer and clamped to `[7, 365]`; `location_id` is parsed and rejected with a 400 if it is not a valid integer; `candidate_id` must be one of the 10 hardcoded candidates; `session_id` must be a string of at most 64 characters.
+3. Read-only warehouse workload. The Worker only issues `SELECT` statements against the attached share, so there is no path from user input to a MotherDuck write. Votes live entirely in the Durable Object.
+
 ## Files
 
 - [`src/index.ts`](src/index.ts) - the whole Worker: the `withClient` Postgres helper, the three read-only SQL handlers, the `/api/votes` routes, the `CITY_COORDS` and `CANDIDATES` lookups, and the `VoteTracker` Durable Object class.
@@ -166,18 +178,6 @@ The first deploy creates the `duckoffee-map` Worker, uploads `./public` through 
 - [`public/style.css`](public/style.css) - the SPA styling, with the brand palette as CSS custom properties at the top.
 - [`public/assets/`](public/assets/) - the hero image (`duckoffee.jpg`), duck and database SVGs, and the `AeonikMono-Regular.woff2` font used by the frontend.
 - [`PROMPT.md`](PROMPT.md) - a self-contained prompt you can paste into a coding agent to rebuild this Worker plus Durable Object plus MotherDuck architecture with your own brand, dataset, and voting question.
-
-## Caveats
-
-- The share URI is interpolated into the `ATTACH` statement, not parameterized. `DUCKOFFEE_SHARE` is operator-controlled config in `wrangler.toml`, not user input, so keep it that way: do not wire it to a request parameter or you reintroduce SQL injection on the attach.
-- Do not put the token in `wrangler.toml`. `MOTHERDUCK_TOKEN` is a Wrangler secret (`wrangler secret put`) in production and lives in `.dev.vars` locally; `.dev.vars` should be gitignored. The `[vars]` block is for non-secret config (host, db, share) only.
-- `nodejs_compat` is required and fails silently if dropped. Remove the flag and the `pg` import breaks at runtime, not at build time. If you see module-resolution errors for `pg`, this is the first thing to check.
-- The Postgres host is region-specific. `pg.us-east-1-aws.motherduck.com` only works for accounts in that region. Point `MOTHERDUCK_HOST` at your own region's endpoint or connections will fail.
-- Sample-data cities have no coordinates. `duckoffee.locations` stores city names but no lat/lon, so any city missing from `CITY_COORDS` returns `lon: null, lat: null` and silently will not plot on the map. Add a coordinate entry for every location you query.
-- Candidate `id` is a permanent key. The `id` in `CANDIDATES` is the value stored in the Durable Object. Renaming it after votes exist orphans those votes under the old key, so pick a stable kebab-case `id` up front.
-- Each browser tab is a distinct voter. The session ID is `sessionStorage`-backed, so two tabs count as two voters, and clearing storage creates a fresh voter. This is fine for a demo, not a substitute for real auth.
-- One client per request. `withClient` opens and closes a `pg` connection per call rather than pooling; that is the simple, correct pattern for the Workers request model, but it is not a high-throughput connection pool.
-- Edge cache hides fresh data. The three SQL endpoints are cached for `DATA_CACHE_TTL_SECONDS` (15 minutes) via the Cloudflare cache, so updates to the share will not appear until the TTL expires. Lower it while developing if you expect the data to change.
 
 ## Learn more
 

--- a/cloudflare-workers/README.md
+++ b/cloudflare-workers/README.md
@@ -48,6 +48,61 @@ postgresql://anyusername:<MOTHERDUCK_TOKEN>@<MOTHERDUCK_HOST>:5432/<MOTHERDUCK_D
 - The endpoint listens on port `5432`. Use `pg.us-east-1-aws.motherduck.com` for US organizations and `pg.eu-central-1-aws.motherduck.com` for EU organizations.
 - `sample_data` is available on every MotherDuck account, so the example works without loading any data first.
 
+## How it works
+
+- `src/index.ts`: builds the connection string, connects with `pg`, routes on `url.pathname`, runs parameterized SQL, and always closes the client in a `finally` block. A failed `connect()` returns a `502` with the error detail.
+- `wrangler.toml`: sets `compatibility_flags = ["nodejs_compat"]` and the non-secret `[vars]` `MOTHERDUCK_HOST` and `MOTHERDUCK_DB`.
+
+## Questions to answer
+
+- Which MotherDuck database and schema should the Worker read from (default is `sample_data` / `nyc`)?
+- Which region is the MotherDuck organization in, US or EU, so the right `MOTHERDUCK_HOST` is set?
+- What routes and queries does the API need to expose, and what inputs do they accept?
+- How should request inputs be validated and bound (this example uses a regex check plus numbered parameters)?
+- Where will the MotherDuck token live (Wrangler secret for deploy, `.dev.vars` for local)?
+
+## Caveats
+
+- `nodejs_compat` is required. `wrangler.toml` must set `compatibility_flags = ["nodejs_compat"]` (it does in this example). Without it the `pg` driver fails to load in the Workers runtime, and the failure is not obvious from the error message.
+- `sslmode=require` is not optional. Dropping it from the connection string makes the connection fail rather than fall back to plaintext.
+- Both `/stats` parameters are required and have no server-side defaults. If `start` or `end` is missing the route returns `400`; it does not silently pick a date range. Validate this expectation if you adapt the route, and do not assume defaults like `2022-01-01`.
+- Bind values as numbered parameters; never string-interpolate request input into SQL. The regex is a first gate, but parameter binding is what prevents injection.
+- Match the bound value's shape to the column type. This example pads dates to `YYYY-MM-DD 00:00:00` so they compare against a `TIMESTAMP`. Passing a bare date or a mismatched type can cause silent zero-row results or a type error.
+- Keep the token out of `wrangler.toml` and out of source. It is a secret (`wrangler secret put` for deploy, `.dev.vars` for local, which should be gitignored). Only non-secret config (`MOTHERDUCK_HOST`, `MOTHERDUCK_DB`) belongs in `[vars]`.
+- Set `MOTHERDUCK_HOST` to your org's region. A US token against the EU host (or vice versa) fails to authenticate.
+- A new Postgres connection is opened and closed per request (`client.connect()` / `client.end()` in a `finally` block). That is fine for low to moderate traffic; for high request volume, consider connection reuse or pooling patterns suited to the Workers runtime.
+
+## What you'll adjust
+
+| Setting | Purpose | Options / example |
+| --- | --- | --- |
+| `MOTHERDUCK_TOKEN` (secret) | MotherDuck access token, the password in the connection string | Set via `npx wrangler secret put MOTHERDUCK_TOKEN`; locally via `.dev.vars` |
+| `MOTHERDUCK_HOST` (`[vars]` in `wrangler.toml`) | Postgres endpoint host | `pg.us-east-1-aws.motherduck.com` (US), `pg.eu-central-1-aws.motherduck.com` (EU) |
+| `MOTHERDUCK_DB` (`[vars]` in `wrangler.toml`) | Database the connection targets | `sample_data`; change to your own database name |
+| `name` (`wrangler.toml`) | Worker / deployment name | `motherduck-taxi-stats` |
+| SQL in `src/index.ts` | The queries served by each route | Replace `nyc.taxi` queries with your own schema, table, and columns |
+| Routes in `src/index.ts` | URL paths the Worker handles | `/` (recent trips), `/stats?start=&end=` (aggregates); add or rename to fit your API |
+| Query parameters | Inputs accepted on a route | `start`, `end` (validated as `YYYY-MM-DD`, passed as numbered `$1`/`$2` params) |
+
+## Run it
+
+Prerequisites: Node.js 18+, a Cloudflare account, and a MotherDuck account with an access token.
+
+```sh
+npm install
+
+# Set the token as a Worker secret (creates the Worker if it does not exist).
+# Wrangler prompts you to sign in to Cloudflare if needed, then asks for the token value.
+npx wrangler secret put MOTHERDUCK_TOKEN
+
+# Local development: put the token in a .dev.vars file first, then start the dev server.
+#   MOTHERDUCK_TOKEN="ey...MY_TOKEN"
+npx wrangler dev
+
+# Deploy to Cloudflare once the Worker is adapted to your needs.
+npx wrangler deploy
+```
+
 ## Security
 
 Always sanitize inputs whenever your application accepts them. The two routes that take a date range do both of the following.
@@ -84,45 +139,6 @@ const result = await client.query(
 
 Here the validated date strings are widened to timestamp literals (`YYYY-MM-DD 00:00:00`) so they compare correctly against the `TIMESTAMP` column `tpep_pickup_datetime`. The range is half-open (`>= start`, `< end`), so the `end` day is excluded.
 
-## What you'll adjust
-
-| Setting | Purpose | Options / example |
-| --- | --- | --- |
-| `MOTHERDUCK_TOKEN` (secret) | MotherDuck access token, the password in the connection string | Set via `npx wrangler secret put MOTHERDUCK_TOKEN`; locally via `.dev.vars` |
-| `MOTHERDUCK_HOST` (`[vars]` in `wrangler.toml`) | Postgres endpoint host | `pg.us-east-1-aws.motherduck.com` (US), `pg.eu-central-1-aws.motherduck.com` (EU) |
-| `MOTHERDUCK_DB` (`[vars]` in `wrangler.toml`) | Database the connection targets | `sample_data`; change to your own database name |
-| `name` (`wrangler.toml`) | Worker / deployment name | `motherduck-taxi-stats` |
-| SQL in `src/index.ts` | The queries served by each route | Replace `nyc.taxi` queries with your own schema, table, and columns |
-| Routes in `src/index.ts` | URL paths the Worker handles | `/` (recent trips), `/stats?start=&end=` (aggregates); add or rename to fit your API |
-| Query parameters | Inputs accepted on a route | `start`, `end` (validated as `YYYY-MM-DD`, passed as numbered `$1`/`$2` params) |
-
-## Questions to answer
-
-- Which MotherDuck database and schema should the Worker read from (default is `sample_data` / `nyc`)?
-- Which region is the MotherDuck organization in, US or EU, so the right `MOTHERDUCK_HOST` is set?
-- What routes and queries does the API need to expose, and what inputs do they accept?
-- How should request inputs be validated and bound (this example uses a regex check plus numbered parameters)?
-- Where will the MotherDuck token live (Wrangler secret for deploy, `.dev.vars` for local)?
-
-## Run it
-
-Prerequisites: Node.js 18+, a Cloudflare account, and a MotherDuck account with an access token.
-
-```sh
-npm install
-
-# Set the token as a Worker secret (creates the Worker if it does not exist).
-# Wrangler prompts you to sign in to Cloudflare if needed, then asks for the token value.
-npx wrangler secret put MOTHERDUCK_TOKEN
-
-# Local development: put the token in a .dev.vars file first, then start the dev server.
-#   MOTHERDUCK_TOKEN="ey...MY_TOKEN"
-npx wrangler dev
-
-# Deploy to Cloudflare once the Worker is adapted to your needs.
-npx wrangler deploy
-```
-
 ## Files
 
 - [`src/index.ts`](src/index.ts): the Worker itself. Builds the Postgres connection string, connects with `pg`, routes on `url.pathname`, validates date inputs, runs parameterized SQL against `nyc.taxi`, and always closes the client in a `finally` block.
@@ -131,19 +147,6 @@ npx wrangler deploy
 - [`tsconfig.json`](tsconfig.json): TypeScript compiler settings for the Worker, including the Cloudflare Workers type definitions.
 - [`package-lock.json`](package-lock.json): the npm lockfile pinning exact dependency versions.
 
-## Caveats
+## Learn more
 
-- `nodejs_compat` is required. `wrangler.toml` must set `compatibility_flags = ["nodejs_compat"]` (it does in this example). Without it the `pg` driver fails to load in the Workers runtime, and the failure is not obvious from the error message.
-- `sslmode=require` is not optional. Dropping it from the connection string makes the connection fail rather than fall back to plaintext.
-- Both `/stats` parameters are required and have no server-side defaults. If `start` or `end` is missing the route returns `400`; it does not silently pick a date range. Validate this expectation if you adapt the route, and do not assume defaults like `2022-01-01`.
-- Bind values as numbered parameters; never string-interpolate request input into SQL. The regex is a first gate, but parameter binding is what prevents injection.
-- Match the bound value's shape to the column type. This example pads dates to `YYYY-MM-DD 00:00:00` so they compare against a `TIMESTAMP`. Passing a bare date or a mismatched type can cause silent zero-row results or a type error.
-- Keep the token out of `wrangler.toml` and out of source. It is a secret (`wrangler secret put` for deploy, `.dev.vars` for local, which should be gitignored). Only non-secret config (`MOTHERDUCK_HOST`, `MOTHERDUCK_DB`) belongs in `[vars]`.
-- Set `MOTHERDUCK_HOST` to your org's region. A US token against the EU host (or vice versa) fails to authenticate.
-- A new Postgres connection is opened and closed per request (`client.connect()` / `client.end()` in a `finally` block). That is fine for low to moderate traffic; for high request volume, consider connection reuse or pooling patterns suited to the Workers runtime.
-
-## How it works / Learn more
-
-- `src/index.ts`: builds the connection string, connects with `pg`, routes on `url.pathname`, runs parameterized SQL, and always closes the client in a `finally` block. A failed `connect()` returns a `502` with the error detail.
-- `wrangler.toml`: sets `compatibility_flags = ["nodejs_compat"]` and the non-secret `[vars]` `MOTHERDUCK_HOST` and `MOTHERDUCK_DB`.
 - For the connection-string format, supported regions, and endpoint behavior, see the MotherDuck Cloudflare Workers interface docs at https://motherduck.com/docs/getting-started/interfaces/serverless/cloudflare-workers/ or ask the `ask_docs_question` MCP tool for deeper MotherDuck or DuckDB questions.

--- a/dbt-ai-prompt/README.md
+++ b/dbt-ai-prompt/README.md
@@ -59,6 +59,25 @@ Two views build on that table:
 - `models/reviews/reviews_attributes_by_product.sql` unnests the array fields (`product_features`, `pros`, `cons`, `competitor_mentions`, `use_case`, `purchase_reason`, `reported_issues`, `quality_concerns`) and re-aggregates them into deduplicated arrays per product with `array_distinct(array_agg(...))`. The result is one row per `parent_asin` holding the distinct set of everything reviewers mentioned.
 - `models/reviews/reviews_attributes_sentiment_by_product.sql` counts positive/neutral/negative sentiment per product and computes a normalized score, `(positive - negative) / total`, ranging from -1 to 1, for both overall reviews and customer-service interactions. `NULLIF(..., 0)` guards against divide-by-zero when a product has no scored rows.
 
+## Questions to answer
+
+- What is the source table of unstructured text, and which columns hold the text to extract from?
+- Which target MotherDuck database and schema should the models write to?
+- What structured fields are wanted out, and what are the allowed values / types for each?
+- Should this run on a sample (the `limit 10` demo) or the full table?
+- Is there a `MOTHERDUCK_TOKEN` with read/write access to the target database?
+- Is the source database created and populated (or, for the demo, is the `webshop-dbt-md-ai` share attached)?
+
+## Caveats
+
+- Do not commit your `MOTHERDUCK_TOKEN`. The repo ships an `.envrc` that exported a real token during development. Treat any token visible in version control as compromised, rotate it, and load tokens from your own environment or a secret manager instead of checking them in.
+- `prompt()` runs once per input row and is billed and rate-limited as an AI call. The model ships with `limit 10` for exactly this reason. Removing the limit on a large table can be slow and costly, so size your run deliberately.
+- LLM output is non-deterministic. Two `dbt run` invocations can return slightly different extractions, so do not rely on byte-stable results. Materializing `reviews_attributes` as a `table` (the default) freezes one run's output for the downstream views; re-running re-extracts.
+- The `accepted_values` test on `sentiment` will fail if `prompt()` ever returns a value outside `positive`/`neutral`/`negative` (for example a capitalized or hedged answer). The `struct_descr` text is guidance, not a hard constraint. Keep the test as a guardrail and tighten the prompt wording, or normalize the column, if it trips.
+- Change `+database: my_db` in `dbt_project.yml` before running. The placeholder `my_db` is not a real database; leave it and `dbt run` writes to (or fails to create) a database called `my_db`.
+- The source must exist and be reachable. `_sources.yml` points at the `webshop-dbt-md-ai` share; if it is not attached, or your own source table is missing, dbt fails at compile/run time rather than silently producing empty output.
+- Empty arrays vs nulls: list fields are instructed to return an empty array when nothing matches. `unnest` drops empty arrays, so products whose reviews mention nothing for a given field simply do not contribute rows in `reviews_attributes_by_product`. That is expected, not a bug.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -73,15 +92,6 @@ Two views build on that table:
 | `path: 'md:'` and `target: dev` in `profiles.yml` | Connection target for dbt | `md:` for MotherDuck, or a local `.duckdb` file path |
 | `MOTHERDUCK_TOKEN` env var | Read/write auth for MotherDuck | A token from your MotherDuck account |
 | `accepted_values` / `not_null` tests in `models/reviews/schema.yml` | Validate the extracted output (e.g. sentiment in positive/neutral/negative) | Adjust to your fields |
-
-## Questions to answer
-
-- What is the source table of unstructured text, and which columns hold the text to extract from?
-- Which target MotherDuck database and schema should the models write to?
-- What structured fields are wanted out, and what are the allowed values / types for each?
-- Should this run on a sample (the `limit 10` demo) or the full table?
-- Is there a `MOTHERDUCK_TOKEN` with read/write access to the target database?
-- Is the source database created and populated (or, for the demo, is the `webshop-dbt-md-ai` share attached)?
 
 ## Run it
 
@@ -118,16 +128,6 @@ ATTACH 'md:_share/webshop-dbt-md-ai/a8a01cac-c4e6-4de1-93bf-bcc4c54aa77f';
 - [`models/reviews/schema.yml`](models/reviews/schema.yml) - model documentation and data tests: column descriptions plus `not_null` and `accepted_values` checks (e.g. `sentiment` must be positive/neutral/negative).
 - [`analyses/`](analyses/), [`macros/`](macros/), [`seeds/`](seeds/), [`snapshots/`](snapshots/), [`tests/`](tests/) - the standard dbt project directories, empty placeholders here (each holds a `.gitkeep`).
 - [`.gitignore`](.gitignore) - ignores dbt build output: `target/`, `dbt_packages/`, and `logs/`.
-
-## Caveats
-
-- Do not commit your `MOTHERDUCK_TOKEN`. The repo ships an `.envrc` that exported a real token during development. Treat any token visible in version control as compromised, rotate it, and load tokens from your own environment or a secret manager instead of checking them in.
-- `prompt()` runs once per input row and is billed and rate-limited as an AI call. The model ships with `limit 10` for exactly this reason. Removing the limit on a large table can be slow and costly, so size your run deliberately.
-- LLM output is non-deterministic. Two `dbt run` invocations can return slightly different extractions, so do not rely on byte-stable results. Materializing `reviews_attributes` as a `table` (the default) freezes one run's output for the downstream views; re-running re-extracts.
-- The `accepted_values` test on `sentiment` will fail if `prompt()` ever returns a value outside `positive`/`neutral`/`negative` (for example a capitalized or hedged answer). The `struct_descr` text is guidance, not a hard constraint. Keep the test as a guardrail and tighten the prompt wording, or normalize the column, if it trips.
-- Change `+database: my_db` in `dbt_project.yml` before running. The placeholder `my_db` is not a real database; leave it and `dbt run` writes to (or fails to create) a database called `my_db`.
-- The source must exist and be reachable. `_sources.yml` points at the `webshop-dbt-md-ai` share; if it is not attached, or your own source table is missing, dbt fails at compile/run time rather than silently producing empty output.
-- Empty arrays vs nulls: list fields are instructed to return an empty array when nothing matches. `unnest` drops empty arrays, so products whose reviews mention nothing for a given field simply do not contribute rows in `reviews_attributes_by_product`. That is expected, not a bug.
 
 ## Learn more
 

--- a/dbt-churn-prediction/README.md
+++ b/dbt-churn-prediction/README.md
@@ -109,6 +109,39 @@ the database under `--write-schema` (`python_churn_model_metrics`,
 `python_churn_current_scores`, `python_churn_survival_summary`). Read the script
 before adapting the model side.
 
+## Questions to answer
+
+- How is churn defined for this business (cancellation window, inactivity window)? This sets the label and `member_churn_grace_period_days`. Write this down first: it becomes the target the model learns.
+- What are the source tables for customers, subscriptions/memberships, usage/activity, and payments, and where do they live? You need four kinds of source data: one customer row per customer, a subscription/contract table, an activity/usage table, and a payment/billing table.
+- Target MotherDuck database and schema for the feature tables (default `subscription_churn`).
+- Full refresh each run, or incremental? Current models rebuild as tables; seeds use `--full-refresh`.
+- What "as of" date should the daily score table use (`churn_as_of_date`), and which historical snapshot dates should labels and features cover (`churn_label_dates()`)?
+- Should the feature tables refresh on a schedule, and at what cadence?
+- MotherDuck token / credentials for cloud runs.
+- Train on the bundled IBM Telco benchmark first, or straight on your own dbt-built history?
+
+## Caveats
+
+- **`--source dbt` refuses the bundled sample on purpose.** The script raises if
+  the training matrix has fewer than 50 rows or fewer than 10 positive labels.
+  The bundled seeds are intentionally tiny: too small for useful machine
+  learning. Replace the seeds with real history before using `--source dbt`, or
+  stick to `--source ibm_telco` for benchmarking.
+- **The time-based split needs history.** `--source dbt` splits on `as_of_date`
+  and requires at least 3 distinct snapshot dates, with non-empty train,
+  validation, and test partitions. One snapshot date will not train.
+- **Snapshot dates are hardcoded.** `churn_label_dates()` in
+  `macros/churn_features.sql` lists fixed dates (Dec 2025 through Mar 2026), and
+  `vars.churn_as_of_date` defaults to `2026-04-15`. For your own data, edit both
+  so the snapshot dates and the "as of" date line up with your history;
+  otherwise the feature/label join produces empty or stale tables.
+- **`--database` is required for `--source dbt`.** Omitting it raises. The
+  script auto-discovers the schema holding `fct_customer_features_historical`
+  (preferring an `analytics` schema), so the dbt build must have run first
+  against the same database.
+- **Don't put your token in config.** `MOTHERDUCK_TOKEN` is a secret: keep it in
+  `.env` locally (gitignored), not as a committed file.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -123,17 +156,6 @@ before adapting the model side.
 | seeds (`seeds/raw_*.csv`) | Sample raw inputs to swap for your own customer, membership, usage, payment data | `raw_customers`, `raw_memberships`, `raw_usage_events`, `raw_payments` |
 | `--source` (training script) | Training data source | `ibm_telco` (runs immediately) or `dbt` (your built tables) |
 | `--write-schema` (training script) | Schema for Python prediction/metric tables written back | `science` (default) |
-
-## Questions to answer
-
-- How is churn defined for this business (cancellation window, inactivity window)? This sets the label and `member_churn_grace_period_days`. Write this down first: it becomes the target the model learns.
-- What are the source tables for customers, subscriptions/memberships, usage/activity, and payments, and where do they live? You need four kinds of source data: one customer row per customer, a subscription/contract table, an activity/usage table, and a payment/billing table.
-- Target MotherDuck database and schema for the feature tables (default `subscription_churn`).
-- Full refresh each run, or incremental? Current models rebuild as tables; seeds use `--full-refresh`.
-- What "as of" date should the daily score table use (`churn_as_of_date`), and which historical snapshot dates should labels and features cover (`churn_label_dates()`)?
-- Should the feature tables refresh on a schedule, and at what cadence?
-- MotherDuck token / credentials for cloud runs.
-- Train on the bundled IBM Telco benchmark first, or straight on your own dbt-built history?
 
 ## Run it
 
@@ -184,28 +206,6 @@ uv run python scripts/train_python_churn_models.py --source dbt --database "md:$
 - [`.env.example`](.env.example) - template for `MOTHERDUCK_TOKEN` and `MOTHERDUCK_DATABASE`; copy to `.env` (gitignored) for cloud runs.
 - `analyses/`, `macros/`, `snapshots/` - standard dbt scaffold dirs, currently placeholders (`.gitkeep`).
 - `uv.lock` - pinned dependency lockfile for `uv`.
-
-## Caveats
-
-- **`--source dbt` refuses the bundled sample on purpose.** The script raises if
-  the training matrix has fewer than 50 rows or fewer than 10 positive labels.
-  The bundled seeds are intentionally tiny: too small for useful machine
-  learning. Replace the seeds with real history before using `--source dbt`, or
-  stick to `--source ibm_telco` for benchmarking.
-- **The time-based split needs history.** `--source dbt` splits on `as_of_date`
-  and requires at least 3 distinct snapshot dates, with non-empty train,
-  validation, and test partitions. One snapshot date will not train.
-- **Snapshot dates are hardcoded.** `churn_label_dates()` in
-  `macros/churn_features.sql` lists fixed dates (Dec 2025 through Mar 2026), and
-  `vars.churn_as_of_date` defaults to `2026-04-15`. For your own data, edit both
-  so the snapshot dates and the "as of" date line up with your history;
-  otherwise the feature/label join produces empty or stale tables.
-- **`--database` is required for `--source dbt`.** Omitting it raises. The
-  script auto-discovers the schema holding `fct_customer_features_historical`
-  (preferring an `analytics` schema), so the dbt build must have run first
-  against the same database.
-- **Don't put your token in config.** `MOTHERDUCK_TOKEN` is a secret: keep it in
-  `.env` locally (gitignored), not as a committed file.
 
 ## Learn more
 

--- a/dbt-dual-execution/README.md
+++ b/dbt-dual-execution/README.md
@@ -64,6 +64,25 @@ from {{ source("tpc-ds", "store_sales") }}
 
 The `tpcds/queries/` models (`query_1.sql` ... `query_99.sql`) are the TPC-DS analytical queries materialized as views on top of the raw models.
 
+## Questions to answer
+
+- Which MotherDuck database(s) should models target, and which models should stay local on disk (no explicit `database=`)?
+- What is the source database and schema the raw models should read from (here `jdw_dev.jdw_tpcds`)? Does it already exist in your account?
+- Should local runs sample the source data, and at what rate, or read it in full?
+- Local-only iteration, cloud-only, or the dual (attach both) setup as configured here?
+- Is a MotherDuck token already configured in the shell, or should auth happen via the browser prompt?
+
+## Caveats
+
+- **Same database name across targets.** `database="my_db"` is hard-coded in the `example/` models. Under `--target local` that name resolves only because `attach: "md:"` brings `my_db` into the session, and under `--target prod` it resolves only if `my_db` exists in your account. If the database does not exist in MotherDuck, the run fails. Create it first or change the name.
+- **Switching targets changes where "local" models land.** Models without `database=` follow the target default. With `--target prod` (default db `md:jdw_dev`) those models materialize in the cloud, not on disk, so `--target prod` is not a true "everything in cloud" run unless every model pins its `database`.
+- **`attach: "md:"` attaches everything.** It pulls in all MotherDuck databases on every local run, which can be slow if you have many. Narrow it to `md:my_db` when you only need one.
+- **Source must exist before the raw models run.** `_sources.yml` points at `jdw_dev.jdw_tpcds`. dbt does not create sources; if that database/schema is absent (or you have not been granted access), the `tpcds` models error. Repoint `_sources.yml` to data you actually have.
+- **Sampling only kicks in on the `local` target.** The `using sample 1 %` clause is gated by `target.name == 'local'`. Renaming the local target, or running under any other target, silently reads the full source, which can be expensive on large tables.
+- **Don't put your token in `profiles.yml`.** Authenticate with the `MOTHERDUCK_TOKEN` environment variable (or the browser prompt), not by committing a token into the profile or connection string.
+- **`*.db` is gitignored.** The local `local.db` file is excluded by `.gitignore`, so local materializations are intentionally not version-controlled; expect a fresh file on a clean checkout.
+- **dbt-duckdb version is pinned.** `pyproject.toml` pins `dbt-duckdb==1.9.3`. The ATTACH/dual-execution behavior here is verified against that version; newer or older releases may differ.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -77,14 +96,6 @@ The `tpcds/queries/` models (`query_1.sql` ... `query_99.sql`) are the TPC-DS an
 | `{% if target.name == 'local' %}` sampling | Reduces source rows on local runs so iteration is fast; full data runs in the cloud. | `using sample 1 %` in `models/tpcds/raw/store_sales.sql` |
 | `dbt_project.yml` model materializations | Default materialization per folder (`example` as views, `tpcds/raw` as tables, `tpcds/queries` as views). | `+materialized: table` / `view`, `+tags: ['raw']` |
 | `threads` (both profile outputs) | dbt concurrency for the run. | `threads: 4` |
-
-## Questions to answer
-
-- Which MotherDuck database(s) should models target, and which models should stay local on disk (no explicit `database=`)?
-- What is the source database and schema the raw models should read from (here `jdw_dev.jdw_tpcds`)? Does it already exist in your account?
-- Should local runs sample the source data, and at what rate, or read it in full?
-- Local-only iteration, cloud-only, or the dual (attach both) setup as configured here?
-- Is a MotherDuck token already configured in the shell, or should auth happen via the browser prompt?
 
 ## Run it
 
@@ -116,17 +127,6 @@ The first cloud run opens a browser prompt for MotherDuck authentication unless 
 - [`analyses/`](analyses/), [`macros/`](macros/), [`seeds/`](seeds/), [`snapshots/`](snapshots/), [`tests/`](tests/) - the standard empty dbt scaffold directories (each holds only a `.gitkeep`).
 - [`.gitignore`](.gitignore) - excludes dbt build output and `*.db`, so the local `local.db` is intentionally not version-controlled.
 - `.python-version`, `.user.yml` - the pinned Python version for `uv` and dbt's per-user invocation id.
-
-## Caveats
-
-- **Same database name across targets.** `database="my_db"` is hard-coded in the `example/` models. Under `--target local` that name resolves only because `attach: "md:"` brings `my_db` into the session, and under `--target prod` it resolves only if `my_db` exists in your account. If the database does not exist in MotherDuck, the run fails. Create it first or change the name.
-- **Switching targets changes where "local" models land.** Models without `database=` follow the target default. With `--target prod` (default db `md:jdw_dev`) those models materialize in the cloud, not on disk, so `--target prod` is not a true "everything in cloud" run unless every model pins its `database`.
-- **`attach: "md:"` attaches everything.** It pulls in all MotherDuck databases on every local run, which can be slow if you have many. Narrow it to `md:my_db` when you only need one.
-- **Source must exist before the raw models run.** `_sources.yml` points at `jdw_dev.jdw_tpcds`. dbt does not create sources; if that database/schema is absent (or you have not been granted access), the `tpcds` models error. Repoint `_sources.yml` to data you actually have.
-- **Sampling only kicks in on the `local` target.** The `using sample 1 %` clause is gated by `target.name == 'local'`. Renaming the local target, or running under any other target, silently reads the full source, which can be expensive on large tables.
-- **Don't put your token in `profiles.yml`.** Authenticate with the `MOTHERDUCK_TOKEN` environment variable (or the browser prompt), not by committing a token into the profile or connection string.
-- **`*.db` is gitignored.** The local `local.db` file is excluded by `.gitignore`, so local materializations are intentionally not version-controlled; expect a fresh file on a clean checkout.
-- **dbt-duckdb version is pinned.** `pyproject.toml` pins `dbt-duckdb==1.9.3`. The ATTACH/dual-execution behavior here is verified against that version; newer or older releases may differ.
 
 ## Learn more
 

--- a/dbt-duckdb-dwh-starter/README.md
+++ b/dbt-duckdb-dwh-starter/README.md
@@ -56,6 +56,24 @@ loads the `dive.tsx` source with DuckDB `read_text()`, substitutes the database
 and `_mart` schema into the source, and creates or updates the Dive in MotherDuck
 with the `MD_CREATE_DIVE` / `MD_UPDATE_DIVE_CONTENT` functions.
 
+## Questions to answer
+
+- Which target domain(s) should the link graph and HN coverage focus on (`commoncrawl_domains`)?
+- Which MotherDuck database and base schema, and dev or prod (`DBT_DUCKDB_PATH`, `DBT_SCHEMA`, `--target`)?
+- Which Common Crawl snapshot, and how many HN stories per domain (`commoncrawl_snapshot`, `hackernews_max_stories_per_domain`)?
+- Is the large Common Crawl edges download acceptable (see Caveats), or should the scope be narrowed first?
+- Deploy the Dive, and as a preview or to production?
+- Is a MotherDuck account and token available, with access to the Hacker News share?
+
+## Caveats
+
+- The Common Crawl edges file is large (~14GB). `stg_commoncrawl__domain_edges` is materialized incrementally so it is not re-downloaded on every run; avoid a casual `--full-refresh` of that model.
+- `DBT_DUCKDB_PATH` and `DBT_SCHEMA` must match between the dbt build and the Dive deploy. If they differ, the Dive points at a database/`_mart` schema that the build did not populate and renders empty.
+- The Hacker News staging model attaches a MotherDuck share (`md:_share/hacker_news/...`); the run needs access to that share.
+- `scripts/deploy-dive.sh` requires the `duckdb` CLI and `jq` on PATH and `MOTHERDUCK_TOKEN` set; it exits early if any are missing.
+- The deploy expects a unique Dive title: if more than one Dive already shares the title it errors instead of guessing which to update. Use `PREVIEW_BRANCH` for non-production deploys.
+- `threads: 24` in `profiles.yml` is aggressive; lower it for smaller machines or plans.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -70,15 +88,6 @@ with the `MD_CREATE_DIVE` / `MD_UPDATE_DIVE_CONTENT` functions.
 | `MOTHERDUCK_TOKEN` (env) | MotherDuck access token for dbt and the Dive deploy. | a token from the MotherDuck UI |
 | `dives/backlinks-hn/dive.tsx` + `dive-manifest.json` | The Dive's React/SQL source and its title/description. | edit tiles, queries, title |
 | `PREVIEW_BRANCH` (env, deploy) | Appends a branch name to the Dive title so a preview does not overwrite production. | `$(git branch --show-current)` |
-
-## Questions to answer
-
-- Which target domain(s) should the link graph and HN coverage focus on (`commoncrawl_domains`)?
-- Which MotherDuck database and base schema, and dev or prod (`DBT_DUCKDB_PATH`, `DBT_SCHEMA`, `--target`)?
-- Which Common Crawl snapshot, and how many HN stories per domain (`commoncrawl_snapshot`, `hackernews_max_stories_per_domain`)?
-- Is the large Common Crawl edges download acceptable (see Caveats), or should the scope be narrowed first?
-- Deploy the Dive, and as a preview or to production?
-- Is a MotherDuck account and token available, with access to the Hacker News share?
 
 ## Run it
 
@@ -143,15 +152,6 @@ The script prints the deployed Dive URL.
 - [`scripts/deploy-dive.sh`](scripts/deploy-dive.sh) - deploys a Dive from `dives/<name>/` via the DuckDB CLI and the `MD_CREATE_DIVE` / `MD_UPDATE_DIVE_CONTENT` functions.
 - [`pyproject.toml`](pyproject.toml) / [`uv.lock`](uv.lock) - Python dependencies (dbt-duckdb) managed with `uv`.
 - [`assets/backlinks-hn-dive.png`](assets/backlinks-hn-dive.png) - screenshot of the deployed Dive.
-
-## Caveats
-
-- The Common Crawl edges file is large (~14GB). `stg_commoncrawl__domain_edges` is materialized incrementally so it is not re-downloaded on every run; avoid a casual `--full-refresh` of that model.
-- `DBT_DUCKDB_PATH` and `DBT_SCHEMA` must match between the dbt build and the Dive deploy. If they differ, the Dive points at a database/`_mart` schema that the build did not populate and renders empty.
-- The Hacker News staging model attaches a MotherDuck share (`md:_share/hacker_news/...`); the run needs access to that share.
-- `scripts/deploy-dive.sh` requires the `duckdb` CLI and `jq` on PATH and `MOTHERDUCK_TOKEN` set; it exits early if any are missing.
-- The deploy expects a unique Dive title: if more than one Dive already shares the title it errors instead of guessing which to update. Use `PREVIEW_BRANCH` for non-production deploys.
-- `threads: 24` in `profiles.yml` is aggressive; lower it for smaller machines or plans.
 
 ## Learn more
 

--- a/dbt-ducklake/README.md
+++ b/dbt-ducklake/README.md
@@ -80,6 +80,35 @@ into the separate native MotherDuck database `my_db`.
 developing against a local DuckLake file instead of MotherDuck; switch with
 `dbt build --target local`.
 
+## Questions to answer
+
+- Source: keep the public `devrel-test-data` TPC-DS bucket, or point at your own parquet and scale factor?
+- DuckLake database: which database name and `DATA_PATH` (S3/object-store prefix) should hold the raw tables?
+- Analytics target: which native MotherDuck database should the query models land in (default `my_db`)?
+- Scope: run all 99 queries plus 25 raw tables, or a subset via `--select` / `--exclude`?
+- Full vs partial: rebuild raw tables every run, or only refresh the query layer?
+- Credentials: MotherDuck token, and read access to the S3 source bucket.
+
+## Caveats
+
+- Create the DuckLake database before the first run. `CREATE DATABASE dbt_ducklake
+  (TYPE ducklake, DATA_PATH '...')` and `my_db` must already exist; dbt does not
+  create them. A missing `dbt_ducklake` fails the run, and a missing `my_db`
+  fails the query layer.
+- `is_ducklake: true` is required, not optional. Without it, the raw tables
+  silently write to native MotherDuck storage instead of your `DATA_PATH` object
+  store, defeating the point of this example. There is no error, just the wrong
+  storage backend.
+- `profiles.yml`'s profile name must match the `profile:` key in `dbt_project.yml`
+  (`dbt_ducklake`). A mismatch makes dbt fail to find a profile.
+- TPC-DS Scale Factor 100 is large. A full `dbt build` materializes 25 raw tables
+  plus 99 query tables and can take a while and consume meaningful memory. For
+  iteration, scope with `--select tag:raw` / `--select tag:queries` or a single
+  model (`--select query_1`).
+- The S3 source bucket needs read access. The public `devrel-test-data` bucket is
+  readable without credentials; if you swap in your own bucket, configure object
+  storage credentials (a MotherDuck/DuckDB secret) or the raw layer fails.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -91,15 +120,6 @@ developing against a local DuckLake file instead of MotherDuck; switch with
 | `dbt_project.yml` raw/queries `+materialized`, `+schema`, `+tags` | Materialization and tagging per layer | raw: `table` in schema `raw`; queries: `table` |
 | `models/tpcds/raw/_sources.yml` `meta.external_location` | S3 location of the TPC-DS parquet | `s3://devrel-test-data/tpcds/sf100/{name}.parquet`; swap for your own bucket or scale factor |
 | dbt selector (`--select` / `--exclude`) | Limit which models run | e.g. `tag:raw`, `tag:queries`, a single `query_1` |
-
-## Questions to answer
-
-- Source: keep the public `devrel-test-data` TPC-DS bucket, or point at your own parquet and scale factor?
-- DuckLake database: which database name and `DATA_PATH` (S3/object-store prefix) should hold the raw tables?
-- Analytics target: which native MotherDuck database should the query models land in (default `my_db`)?
-- Scope: run all 99 queries plus 25 raw tables, or a subset via `--select` / `--exclude`?
-- Full vs partial: rebuild raw tables every run, or only refresh the query layer?
-- Credentials: MotherDuck token, and read access to the S3 source bucket.
 
 ## Run it
 
@@ -137,26 +157,6 @@ TPC-DS Scale Factor 100 is heavy. For iteration, scope the run with
 - [`.python-version`](.python-version) - pins the local Python version (3.12) for uv.
 - [`.user.yml`](.user.yml) / [`.gitignore`](.gitignore) - dbt anonymous-usage user id, and ignore rules for `target/`, `dbt_packages/`, `logs/`, and `*.db`.
 - [`analyses/`](analyses/), [`macros/`](macros/), [`seeds/`](seeds/), [`snapshots/`](snapshots/), [`tests/`](tests/) - empty standard dbt scaffold directories (each holds a `.gitkeep`).
-
-## Caveats
-
-- Create the DuckLake database before the first run. `CREATE DATABASE dbt_ducklake
-  (TYPE ducklake, DATA_PATH '...')` and `my_db` must already exist; dbt does not
-  create them. A missing `dbt_ducklake` fails the run, and a missing `my_db`
-  fails the query layer.
-- `is_ducklake: true` is required, not optional. Without it, the raw tables
-  silently write to native MotherDuck storage instead of your `DATA_PATH` object
-  store, defeating the point of this example. There is no error, just the wrong
-  storage backend.
-- `profiles.yml`'s profile name must match the `profile:` key in `dbt_project.yml`
-  (`dbt_ducklake`). A mismatch makes dbt fail to find a profile.
-- TPC-DS Scale Factor 100 is large. A full `dbt build` materializes 25 raw tables
-  plus 99 query tables and can take a while and consume meaningful memory. For
-  iteration, scope with `--select tag:raw` / `--select tag:queries` or a single
-  model (`--select query_1`).
-- The S3 source bucket needs read access. The public `devrel-test-data` bucket is
-  readable without credentials; if you swap in your own bucket, configure object
-  storage credentials (a MotherDuck/DuckDB secret) or the raw layer fails.
 
 ## Learn more
 

--- a/dbt-ingestion-s3/README.md
+++ b/dbt-ingestion-s3/README.md
@@ -48,6 +48,27 @@ models are:
 The same project runs unchanged against a local DuckDB file or against
 MotherDuck; only the dbt target changes.
 
+## Questions to answer
+
+- What is the source data: which S3/HTTPS path and file, and is it Parquet or CSV?
+- Which models are actually needed (keep the three samples, replace them, or select a subset)?
+- Target MotherDuck database and schema for the built tables.
+- Local DuckDB run or MotherDuck run?
+- Is there a MotherDuck account and access token available?
+
+## Caveats
+
+- **The target database must already exist.** dbt does not create it. The `prod`
+  target connects to `md:hacker_news_stats`, which fails if the database is
+  missing. Run `CREATE DATABASE IF NOT EXISTS ...` first.
+- **No `dev` target exists.** `profiles.yml` defines `local` and `prod` only. dbt
+  errors on `--target dev`.
+- **Swapping to a private bucket needs a secret.** The default S3 dataset is
+  public. Pointing `external_location` at a private bucket requires a DuckDB/
+  MotherDuck `SECRET`; the project ships none.
+- **Do not put a token in source or config.** The `local` and `prod` runs read
+  `MOTHERDUCK_TOKEN` from the environment; keep it out of the repo.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -59,14 +80,6 @@ MotherDuck; only the dbt target changes.
 | `profiles.yml` targets | Local vs cloud destination. | `local` (`local.db` DuckDB file) or `prod` (`md:hacker_news_stats`) |
 | `profiles.yml` `prod` `path` | The MotherDuck database dbt builds into. | `md:hacker_news_stats`; create the database first |
 | `MOTHERDUCK_TOKEN` (env) | Auth for MotherDuck runs. | a read/write token from your account |
-
-## Questions to answer
-
-- What is the source data: which S3/HTTPS path and file, and is it Parquet or CSV?
-- Which models are actually needed (keep the three samples, replace them, or select a subset)?
-- Target MotherDuck database and schema for the built tables.
-- Local DuckDB run or MotherDuck run?
-- Is there a MotherDuck account and access token available?
 
 ## Run it
 
@@ -105,19 +118,6 @@ stays on disk. There is no `dev` target; use `local`.
 - [`pyproject.toml`](pyproject.toml): Python project metadata for local `uv run` (pins `dbt-duckdb==1.9.3`).
 - [`uv.lock`](uv.lock): resolved lockfile for the local `uv` environment. [`.python-version`](.python-version) pins Python 3.12.
 - [`analyses/`](analyses/), [`macros/`](macros/), [`seeds/`](seeds/), [`snapshots/`](snapshots/), [`tests/`](tests/): standard dbt scaffold directories, empty for now (each holds a `.gitkeep`).
-
-## Caveats
-
-- **The target database must already exist.** dbt does not create it. The `prod`
-  target connects to `md:hacker_news_stats`, which fails if the database is
-  missing. Run `CREATE DATABASE IF NOT EXISTS ...` first.
-- **No `dev` target exists.** `profiles.yml` defines `local` and `prod` only. dbt
-  errors on `--target dev`.
-- **Swapping to a private bucket needs a secret.** The default S3 dataset is
-  public. Pointing `external_location` at a private bucket requires a DuckDB/
-  MotherDuck `SECRET`; the project ships none.
-- **Do not put a token in source or config.** The `local` and `prod` runs read
-  `MOTHERDUCK_TOKEN` from the environment; keep it out of the repo.
 
 ## Learn more
 

--- a/dbt-local-ducklake/README.md
+++ b/dbt-local-ducklake/README.md
@@ -98,6 +98,26 @@ local_sqlite:
   CALL ducklake_cleanup_old_files('catalog', cleanup_all => true);
   ```
 
+## Questions to answer
+
+- Which DuckLake backend: local Postgres, local SQLite, or a managed catalog on MotherDuck (`md:`)?
+- What is the source data: keep TPC-H, or repoint `external_location` to your own parquet / object-storage path?
+- What scale factor should the benchmark data use (full ~10GB vs a small dev sample)?
+- Which target database and schema should models materialize into (defaults: `catalog.raw` and `catalog.prep`)?
+- For the local Postgres target, what are the metadata store credentials (host, port, database)?
+- Should DuckLake maintenance (compaction, snapshot expiry) run, and on what cadence?
+
+## Caveats
+
+- **Postgres database must exist first.** The `local` target attaches `ducklake:postgres:` against a `ducklake_catalog` database. dbt will not create it for you. Run `createdb ducklake_catalog` (or the equivalent) before `dbt build`, or the attach fails.
+- **Secrets do not belong in `profiles.yml`.** The shipped Postgres secret has no password (local trust auth). For any non-local Postgres, supply credentials via environment variables / a dbt secret resolver, not by committing them here.
+- **`core_nightly` is a moving target.** The DuckLake extension is pinned to the `core_nightly` repo, so behavior can change between builds. Pin to a released DuckLake version once one is available if you need reproducibility.
+- **Snapshot expiry is aggressive.** `maintain_ducklake()` expires snapshots `older_than => now() - INTERVAL '1 minute'` even though its log line says "1 hour". Running it discards almost all time-travel history immediately. Widen the interval before relying on it in any environment where you want to keep snapshots.
+- **`merge_adjacent_files` and friends are DuckLake-only.** These maintenance calls only resolve when the attached catalog is a DuckLake. Running the macro against a plain DuckDB attach will error.
+- **The `motherduck` target uses a hardcoded database name.** `md:jdw_ducklake` is an example database. Point it at your own MotherDuck DuckLake database and set `motherduck_token` in the environment, or the attach fails silently to authenticate.
+- **Scale factor 10 generates ~10GB.** Generating and materializing the full set is slow and disk-heavy. Use `--scale-factor 1` (or lower) for fast iteration; the same models work at any scale.
+- **`data/`, `data_files/`, and `*.db` are gitignored.** The generated parquet, DuckLake data files, and SQLite metadata are intentionally not committed. A fresh clone has to regenerate data and rebuild before queries return rows.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -112,15 +132,6 @@ local_sqlite:
 | `models.dbt_local_ducklake.tpch` (dbt_project.yml) | Where models land in the catalog | `raw` -> `catalog.raw` (tables), `queries` -> `catalog.prep` (tables) |
 | TPC-H scale factor | Size of the generated benchmark data | `--scale-factor 10` (~10GB); lower it (e.g. `1` for ~1GB) for a fast local run |
 | `maintain_ducklake()` (macros/ducklake_maintenance.sql) | Compaction and snapshot cleanup cadence | merges adjacent files, then `ducklake_expire_snapshots(... older_than => now() - INTERVAL '1 minute')` and `ducklake_cleanup_old_files`; tune the interval |
-
-## Questions to answer
-
-- Which DuckLake backend: local Postgres, local SQLite, or a managed catalog on MotherDuck (`md:`)?
-- What is the source data: keep TPC-H, or repoint `external_location` to your own parquet / object-storage path?
-- What scale factor should the benchmark data use (full ~10GB vs a small dev sample)?
-- Which target database and schema should models materialize into (defaults: `catalog.raw` and `catalog.prep`)?
-- For the local Postgres target, what are the metadata store credentials (host, port, database)?
-- Should DuckLake maintenance (compaction, snapshot expiry) run, and on what cadence?
 
 ## Run it
 
@@ -170,17 +181,6 @@ duckdb -c "INSTALL ducklake; LOAD ducklake; \
 - [`macros/ducklake_maintenance.sql`](macros/ducklake_maintenance.sql) - the `maintain_ducklake()` operation: merges adjacent files, expires old snapshots, and cleans up orphaned data files.
 - [`.user.yml`](.user.yml) - dbt's per-user identifier file (anonymous usage tracking).
 - `analyses/`, `seeds/`, `snapshots/`, `tests/`, `macros/` - the standard dbt project directories, kept as empty placeholders except for the macros above.
-
-## Caveats
-
-- **Postgres database must exist first.** The `local` target attaches `ducklake:postgres:` against a `ducklake_catalog` database. dbt will not create it for you. Run `createdb ducklake_catalog` (or the equivalent) before `dbt build`, or the attach fails.
-- **Secrets do not belong in `profiles.yml`.** The shipped Postgres secret has no password (local trust auth). For any non-local Postgres, supply credentials via environment variables / a dbt secret resolver, not by committing them here.
-- **`core_nightly` is a moving target.** The DuckLake extension is pinned to the `core_nightly` repo, so behavior can change between builds. Pin to a released DuckLake version once one is available if you need reproducibility.
-- **Snapshot expiry is aggressive.** `maintain_ducklake()` expires snapshots `older_than => now() - INTERVAL '1 minute'` even though its log line says "1 hour". Running it discards almost all time-travel history immediately. Widen the interval before relying on it in any environment where you want to keep snapshots.
-- **`merge_adjacent_files` and friends are DuckLake-only.** These maintenance calls only resolve when the attached catalog is a DuckLake. Running the macro against a plain DuckDB attach will error.
-- **The `motherduck` target uses a hardcoded database name.** `md:jdw_ducklake` is an example database. Point it at your own MotherDuck DuckLake database and set `motherduck_token` in the environment, or the attach fails silently to authenticate.
-- **Scale factor 10 generates ~10GB.** Generating and materializing the full set is slow and disk-heavy. Use `--scale-factor 1` (or lower) for fast iteration; the same models work at any scale.
-- **`data/`, `data_files/`, and `*.db` are gitignored.** The generated parquet, DuckLake data files, and SQLite metadata are intentionally not committed. A fresh clone has to regenerate data and rebuild before queries return rows.
 
 ## Learn more
 

--- a/dbt-metricflow/README.md
+++ b/dbt-metricflow/README.md
@@ -77,6 +77,25 @@ DBT_PROFILES_DIR=.. uv run dbt run
 DBT_PROFILES_DIR=.. uv run mf query --metrics cancellation_rate
 ```
 
+## Questions to answer
+
+- What is the source fact table and its grain (one row per order, event, session)?
+- Which metrics matter (sums, counts, distinct counts, derived ratios) and what are their labels?
+- What time grain and date range should the time spine cover?
+- Run against local DuckDB only, MotherDuck only, or both (promote local to cloud)?
+- For MotherDuck: which database name, and is a MotherDuck token available?
+
+## Caveats
+
+- **Build before you query.** `mf query` reads materialized tables, not the YAML alone. Run `dbt seed` and `dbt run` first, or you get empty or error results. After changing `semantic_models.yml`, re-run `dbt run`.
+- **`DBT_PROFILES_DIR=..` is mandatory** when running from `ecommerce_metrics/`, because `profiles.yml` lives one level up in `metricflow-example/`. Without it dbt looks in `~/.dbt/` and fails to find the profile.
+- **dbt and `mf` pick targets differently.** `dbt` uses `--target motherduck`; the `mf` CLI ignores `--target` and reads `DBT_TARGET`. Setting only one runs half your flow against the wrong database, often silently.
+- **Time-dimension queries are bounded by the spine.** `metricflow_time_spine.sql` only generates dates from `2024-01-01` to `2025-12-31`. Grouping by `metric_time__*` outside that window returns no rows. Widen the `generate_series` range to query other periods.
+- **Only the `day` grain is declared.** The time spine and `dbt_project.yml` define a `day` granularity; `metric_time__month`, `__week`, and `__year` roll up from it. If you need a coarser native grain you must add it to the spine config.
+- **MotherDuck token env var naming.** dbt-duckdb accepts `MOTHERDUCK_TOKEN` or `motherduck_token`. The token is read from the environment, not from `profiles.yml` (do not paste secrets into the profile). A missing or invalid token fails at connection time, not at parse time.
+- **Create the MotherDuck database first.** `md:ecommerce_test_db` must exist before `dbt run` writes into it; the one-time `CREATE DATABASE` step above handles this. dbt will not create the database for you.
+- **Derived metrics reference metric names, not measures.** `revenue_per_customer` uses `revenue / customers`, both of which are metrics. Referencing a raw measure name in a derived `expr` will not resolve. Metric declaration order in the file does not matter; MetricFlow resolves the whole graph.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -91,14 +110,6 @@ DBT_PROFILES_DIR=.. uv run mf query --metrics cancellation_rate
 | `models/semantic_models.yml` | Semantic model: entities, dimensions, measures, metrics | add/edit measures and metrics here to define new KPIs |
 | `models/fct_orders.sql` + `seeds/raw_orders.csv` | The fact table and its source rows | swap the seed and fact model for your own grain/columns |
 | `models/metricflow_time_spine.sql` | Date spine backing time dimensions | `generate_series` range, currently `2024-01-01` to `2025-12-31` |
-
-## Questions to answer
-
-- What is the source fact table and its grain (one row per order, event, session)?
-- Which metrics matter (sums, counts, distinct counts, derived ratios) and what are their labels?
-- What time grain and date range should the time spine cover?
-- Run against local DuckDB only, MotherDuck only, or both (promote local to cloud)?
-- For MotherDuck: which database name, and is a MotherDuck token available?
 
 ## Run it
 
@@ -155,17 +166,6 @@ The generated SQL is identical for both targets. MotherDuck's hybrid execution d
 - [`metricflow-example/ecommerce_metrics/seeds/raw_orders.csv`](metricflow-example/ecommerce_metrics/seeds/raw_orders.csv): the 20-row source order data loaded by `dbt seed`.
 - [`metricflow-example/ecommerce_metrics/README.md`](metricflow-example/ecommerce_metrics/README.md): the default dbt starter README (unmodified boilerplate).
 - `metricflow-example/ecommerce_metrics/` also holds the standard dbt scaffold dirs (`analyses/`, `macros/`, `snapshots/`, `tests/`), each with a `.gitkeep` placeholder and otherwise empty.
-
-## Caveats
-
-- **Build before you query.** `mf query` reads materialized tables, not the YAML alone. Run `dbt seed` and `dbt run` first, or you get empty or error results. After changing `semantic_models.yml`, re-run `dbt run`.
-- **`DBT_PROFILES_DIR=..` is mandatory** when running from `ecommerce_metrics/`, because `profiles.yml` lives one level up in `metricflow-example/`. Without it dbt looks in `~/.dbt/` and fails to find the profile.
-- **dbt and `mf` pick targets differently.** `dbt` uses `--target motherduck`; the `mf` CLI ignores `--target` and reads `DBT_TARGET`. Setting only one runs half your flow against the wrong database, often silently.
-- **Time-dimension queries are bounded by the spine.** `metricflow_time_spine.sql` only generates dates from `2024-01-01` to `2025-12-31`. Grouping by `metric_time__*` outside that window returns no rows. Widen the `generate_series` range to query other periods.
-- **Only the `day` grain is declared.** The time spine and `dbt_project.yml` define a `day` granularity; `metric_time__month`, `__week`, and `__year` roll up from it. If you need a coarser native grain you must add it to the spine config.
-- **MotherDuck token env var naming.** dbt-duckdb accepts `MOTHERDUCK_TOKEN` or `motherduck_token`. The token is read from the environment, not from `profiles.yml` (do not paste secrets into the profile). A missing or invalid token fails at connection time, not at parse time.
-- **Create the MotherDuck database first.** `md:ecommerce_test_db` must exist before `dbt run` writes into it; the one-time `CREATE DATABASE` step above handles this. dbt will not create the database for you.
-- **Derived metrics reference metric names, not measures.** `revenue_per_customer` uses `revenue / customers`, both of which are metrics. Referencing a raw measure name in a derived `expr` will not resolve. Metric declaration order in the file does not matter; MetricFlow resolves the whole graph.
 
 ## Learn more
 

--- a/dlt-db-replication/README.md
+++ b/dlt-db-replication/README.md
@@ -47,6 +47,28 @@ pipeline.run(source, write_disposition="replace")
 - `[destination.motherduck] batch_size = 1000000` trades memory for throughput. Large batches load faster but hold more in memory.
 - `[data_writer] format = "parquet"` is the interim format dlt writes before loading. Parquet gives good compression and load performance.
 
+## Questions to answer
+
+- Source database: which PostgreSQL host, database, and schema?
+- Which tables to replicate, and is the list stable or changing often?
+- Load strategy: full refresh (`replace`, current default) or incremental (`merge`/`append` with a cursor/primary key)?
+- Target MotherDuck database and dataset (schema) name?
+- Expected data volume, so extract/normalize/load workers and `batch_size` can be tuned?
+- Credentials: PostgreSQL username/password and a MotherDuck access token, and where they should live (`secrets.toml` vs environment).
+- How often should this run, and from where (local, CI, an orchestrator)?
+
+## Caveats
+
+- **`secrets.toml` is required and gitignored.** It is not committed and does not exist until you create it. A missing or partial file fails the run; do not put the MotherDuck token or PostgreSQL password in `config.toml`, which is committed.
+- **Full refresh by default.** `write_disposition="replace"` drops and recreates every listed table on each run. It does not preserve history or do change data capture. Switch to `merge`/`append` for incremental loads.
+- **No tables configured raises early.** If `[sources.sql_database.tables]` is empty or missing, the pipeline raises `ValueError` before connecting. This is intentional, so the table list must be set in `config.toml`.
+- **A stale `table` key is in `config.toml`.** Alongside the real `tables` list there is a leftover singular `table = ["call_center"]` entry marked deprecated. The code reads `tables` (plural) only; ignore or delete the `table` key so you don't edit the wrong one.
+- **ConnectorX is version-pinned.** `connectorx<0.4.2` is a hard upper bound. Loosening it can break extraction.
+- **Metrics ignore `[runtime] log_level`.** `print_pipeline_metrics` logs through its own `pipeline_metrics` logger at `INFO` with `propagate=False`, so the metrics summary always prints even though `config.toml` sets the dlt runtime `log_level` to `WARNING`. The two log levels are independent; raising or lowering `[runtime] log_level` will not silence or surface the metrics block.
+- **Worker/pool mismatch stalls extraction.** Setting `[sources.sql_database] workers` higher than `[postgres] pool_size` exhausts the connection pool. Keep them equal.
+- **Memory pressure under heavy load.** Large `batch_size` plus high worker counts can cause out-of-memory errors on big tables. Reduce `batch_size` or worker counts if you hit OOM.
+- **Connection failures.** If extraction cannot reach the source, verify the PostgreSQL credentials in `secrets.toml`, the `host`/`port`, and network reachability from where the pipeline runs.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -62,16 +84,6 @@ pipeline.run(source, write_disposition="replace")
 | `[destination.motherduck] batch_size` in `.dlt/config.toml` | Rows per load batch (memory vs throughput) | `1000000` |
 | `[data_writer] format` in `.dlt/config.toml` | Interim file format | `parquet` |
 | `[runtime] log_level` in `.dlt/config.toml` | dlt log verbosity (does NOT control the metrics output) | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
-
-## Questions to answer
-
-- Source database: which PostgreSQL host, database, and schema?
-- Which tables to replicate, and is the list stable or changing often?
-- Load strategy: full refresh (`replace`, current default) or incremental (`merge`/`append` with a cursor/primary key)?
-- Target MotherDuck database and dataset (schema) name?
-- Expected data volume, so extract/normalize/load workers and `batch_size` can be tuned?
-- Credentials: PostgreSQL username/password and a MotherDuck access token, and where they should live (`secrets.toml` vs environment).
-- How often should this run, and from where (local, CI, an orchestrator)?
 
 ## Run it
 
@@ -125,18 +137,6 @@ The run connects to PostgreSQL, extracts the configured tables in parallel, norm
 - [`pyproject.toml`](pyproject.toml) - project metadata and dependencies (`dlt[motherduck]`, version-pinned `connectorx`, `psycopg2-binary`, `sqlalchemy`, `humanize`), resolved by `uv`.
 - [`uv.lock`](uv.lock) - pinned dependency lockfile for reproducible `uv` installs.
 - [`.gitignore`](.gitignore) - excludes `secrets.toml`, `.env`, Python build artifacts, and local `*.duckdb` files.
-
-## Caveats
-
-- **`secrets.toml` is required and gitignored.** It is not committed and does not exist until you create it. A missing or partial file fails the run; do not put the MotherDuck token or PostgreSQL password in `config.toml`, which is committed.
-- **Full refresh by default.** `write_disposition="replace"` drops and recreates every listed table on each run. It does not preserve history or do change data capture. Switch to `merge`/`append` for incremental loads.
-- **No tables configured raises early.** If `[sources.sql_database.tables]` is empty or missing, the pipeline raises `ValueError` before connecting. This is intentional, so the table list must be set in `config.toml`.
-- **A stale `table` key is in `config.toml`.** Alongside the real `tables` list there is a leftover singular `table = ["call_center"]` entry marked deprecated. The code reads `tables` (plural) only; ignore or delete the `table` key so you don't edit the wrong one.
-- **ConnectorX is version-pinned.** `connectorx<0.4.2` is a hard upper bound. Loosening it can break extraction.
-- **Metrics ignore `[runtime] log_level`.** `print_pipeline_metrics` logs through its own `pipeline_metrics` logger at `INFO` with `propagate=False`, so the metrics summary always prints even though `config.toml` sets the dlt runtime `log_level` to `WARNING`. The two log levels are independent; raising or lowering `[runtime] log_level` will not silence or surface the metrics block.
-- **Worker/pool mismatch stalls extraction.** Setting `[sources.sql_database] workers` higher than `[postgres] pool_size` exhausts the connection pool. Keep them equal.
-- **Memory pressure under heavy load.** Large `batch_size` plus high worker counts can cause out-of-memory errors on big tables. Reduce `batch_size` or worker counts if you hit OOM.
-- **Connection failures.** If extraction cannot reach the source, verify the PostgreSQL credentials in `secrets.toml`, the `host`/`port`, and network reachability from where the pipeline runs.
 
 ## Learn more
 

--- a/flight-plans/flight-bigquery-ingest/README.md
+++ b/flight-plans/flight-bigquery-ingest/README.md
@@ -72,6 +72,86 @@ result. If you flip to `"query"`, push the date filter into the query's `WHERE`
 on a partitioned column so BigQuery still prunes partitions; a query that scans
 the whole table every run gets expensive fast.
 
+## How it works
+
+`flight.py` runs a fixed sequence; only the USER-EDIT BLOCKS change its inputs:
+
+1. Materialize GCP credentials. If `GOOGLE_APPLICATION_CREDENTIALS` already
+   points at a file (local run), use it. Otherwise read the SA JSON from the
+   resolved secret env var, validate it parses as JSON, write it to a private
+   temp file, and set `GOOGLE_APPLICATION_CREDENTIALS` to that path.
+2. Connect DuckDB in memory with community extensions enabled, `INSTALL`/`LOAD`
+   the `bigquery` extension, `LOAD motherduck`, `ATTACH 'md:'`, and set
+   `preserve_insertion_order = FALSE`.
+3. Ensure the destination exists. Create the database and schema, then bootstrap
+   the table by running the source read (`bigquery_scan` or `bigquery_query`,
+   per `READ_MODE`) over a 1970-01-01 window (BigQuery prunes the partitioned
+   scan to nothing, so the probe is nearly free) with
+   `CREATE TABLE IF NOT EXISTS ... AS SELECT ... LIMIT 0`, which takes the result
+   schema without rows.
+4. Resolve the partition window. Priority: explicit `start_dt`+`end_dt`
+   (inclusive backfill range), then `target_dt` (single day), otherwise watermark
+   mode (`prev_max = MAX(partition column)`; load
+   `[prev_max + 1 - OVERLAP_DAYS, prev_max + 1]`; cold start at `COLD_START_DT`
+   when empty).
+5. For each day in the window, run one transaction: `DELETE` rows matching
+   `MD_DELETE_PREDICATE` for that day, then `INSERT` the day's source read
+   (`bigquery_scan(SCAN_TABLE, filter=...)` in scan mode, or
+   `bigquery_query(GCP_PROJECT_ID, QUERY)` in query mode). Commit on success,
+   roll back on error. Per-phase timing (DELETE, then BigQuery read plus
+   MotherDuck insert) is logged to stdout, which Flight logs capture.
+
+The DELETE plus INSERT per partition is what makes a re-run safe: re-loading a
+day clears its rows first, so you never get duplicates, and a failed day rolls
+back cleanly rather than leaving a half-loaded partition.
+
+## Questions to answer
+
+- Do you actually need GoogleSQL (a join, aggregation, function, derived column, or a view)? If not, keep `READ_MODE = "scan"`. If so, switch to `"query"`. See [Which read mode?](#which-read-mode-bigquery_scan-vs-bigquery_query).
+- Which BigQuery table do you want to load (scan mode: `SCAN_TABLE` + `SCAN_COLUMNS`; query mode: the `FROM` in `QUERY`), and which result column is the partition date?
+- Is the source partitioned on that date column so the `{start_dt}`/`{end_dt}` filter actually prunes scans?
+- What is the destination `database.schema.table` in MotherDuck?
+- What is your GCP billing project (the project charged for the read), and is it the right one for cost attribution?
+- How far back should a cold start go (`COLD_START_DT`), and how many days of overlap heal late-arriving data (`OVERLAP_DAYS`)?
+- Do the active read filter (`SCAN_FILTER` or `QUERY`) and `MD_DELETE_PREDICATE` filter on exactly the same predicates, so the DELETE never clears rows you are not re-loading?
+- Which service account can run the read, and how is its JSON key stored (a file locally, a `TYPE flights` secret when deployed)?
+- What schedule (cron, UTC) matches how often the source data lands?
+
+## Caveats
+
+- **No credential-free smoke test.** Unlike the `sample_data` templates here,
+  this Flight needs a real BigQuery source: a GCP billing project and a
+  service-account key. There is no public dataset path that exercises the whole
+  flow without credentials.
+- **BigQuery costs money — scan is the cheaper default.** In scan mode,
+  `bigquery_scan` reads through the Storage Read API, billed on the storage-read
+  meter; the `SCAN_FILTER` row restriction on a partitioned column prunes
+  partitions so you only read the days you load. In query mode, `bigquery_query`
+  runs through the Jobs API, billed by bytes scanned (~5–6× the per-byte rate of
+  the storage-read meter) — push the date filter into `QUERY`'s WHERE on a
+  partitioned column so BigQuery still prunes. Either way, a read that scans the
+  full table every run gets expensive fast. Prefer scan unless you need GoogleSQL
+  (see [Which read mode?](#which-read-mode-bigquery_scan-vs-bigquery_query)).
+- **Predicate mirroring is a footgun.** `MD_DELETE_PREDICATE` must select exactly
+  the rows one partition's read produces. If the active read filter (`SCAN_FILTER`
+  or `QUERY`) filters on `event_source` but the DELETE does not, the DELETE clears
+  rows you are not re-loading and you lose data. Keep them in lockstep, and note
+  the quoting difference: the BigQuery-side `SCAN_FILTER`/`QUERY` use double quotes
+  for string literals, the DuckDB-side `MD_DELETE_PREDICATE` uses single quotes.
+- **Watermark and time zones.** The watermark is computed from
+  `MAX(PARTITION_DATE_COLUMN)`, a date, so it is timezone-free as long as the
+  column is a true partition DATE. Scan mode reads the stored DATE column
+  directly. In query mode, if your partition date is derived from a timestamp,
+  derive it the same way in `QUERY` every run (for example `DATE(event_timestamp)`
+  in a consistent zone), or the day boundaries will drift. A deployed Flight runs
+  in UTC; a local `uv run` uses your machine's timezone.
+- **`OVERLAP_DAYS` trades cost for freshness.** A larger overlap heals
+  later-arriving data but re-scans and re-loads more partitions every run. Set it
+  to the longest delay you expect for late rows, no more.
+- **Cold start can be large.** A watermark cold start loads a single day
+  (`COLD_START_DT`). To backfill history, run once with `start_dt`/`end_dt`
+  spanning the range before you rely on the watermark.
+
 ## What you'll adjust
 
 The read mode, source, and destination live in USER-EDIT BLOCKS at the top of
@@ -99,18 +179,6 @@ GCP billing project, and the service-account credentials.
 | `start_dt` / `end_dt` / `target_dt` | env var (optional) | (unset) | Override the window: explicit inclusive backfill range, or a single day. Unset = watermark mode. |
 | `BIGQUERY_DEST_DB` | Flight config / env var (optional) | `DEFAULT_DB` | Override the destination database without editing code. |
 | `MOTHERDUCK_TOKEN` | Flight-injected | (Flight-injected) | Auth. Select a token on the Flight; never hard-code it. |
-
-## Questions to answer
-
-- Do you actually need GoogleSQL (a join, aggregation, function, derived column, or a view)? If not, keep `READ_MODE = "scan"`. If so, switch to `"query"`. See [Which read mode?](#which-read-mode-bigquery_scan-vs-bigquery_query).
-- Which BigQuery table do you want to load (scan mode: `SCAN_TABLE` + `SCAN_COLUMNS`; query mode: the `FROM` in `QUERY`), and which result column is the partition date?
-- Is the source partitioned on that date column so the `{start_dt}`/`{end_dt}` filter actually prunes scans?
-- What is the destination `database.schema.table` in MotherDuck?
-- What is your GCP billing project (the project charged for the read), and is it the right one for cost attribution?
-- How far back should a cold start go (`COLD_START_DT`), and how many days of overlap heal late-arriving data (`OVERLAP_DAYS`)?
-- Do the active read filter (`SCAN_FILTER` or `QUERY`) and `MD_DELETE_PREDICATE` filter on exactly the same predicates, so the DELETE never clears rows you are not re-loading?
-- Which service account can run the read, and how is its JSON key stored (a file locally, a `TYPE flights` secret when deployed)?
-- What schedule (cron, UTC) matches how often the source data lands?
 
 ## Run it
 
@@ -189,74 +257,6 @@ add a schedule (for example `0 6 * * *`, daily at 06:00 UTC) by updating the
 Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates are
 metadata-only and do not create a new Flight version. For a one-off backfill, set `start_dt`/`end_dt` (or `target_dt`)
 in the run config.
-
-## How it works
-
-`flight.py` runs a fixed sequence; only the USER-EDIT BLOCKS change its inputs:
-
-1. Materialize GCP credentials. If `GOOGLE_APPLICATION_CREDENTIALS` already
-   points at a file (local run), use it. Otherwise read the SA JSON from the
-   resolved secret env var, validate it parses as JSON, write it to a private
-   temp file, and set `GOOGLE_APPLICATION_CREDENTIALS` to that path.
-2. Connect DuckDB in memory with community extensions enabled, `INSTALL`/`LOAD`
-   the `bigquery` extension, `LOAD motherduck`, `ATTACH 'md:'`, and set
-   `preserve_insertion_order = FALSE`.
-3. Ensure the destination exists. Create the database and schema, then bootstrap
-   the table by running the source read (`bigquery_scan` or `bigquery_query`,
-   per `READ_MODE`) over a 1970-01-01 window (BigQuery prunes the partitioned
-   scan to nothing, so the probe is nearly free) with
-   `CREATE TABLE IF NOT EXISTS ... AS SELECT ... LIMIT 0`, which takes the result
-   schema without rows.
-4. Resolve the partition window. Priority: explicit `start_dt`+`end_dt`
-   (inclusive backfill range), then `target_dt` (single day), otherwise watermark
-   mode (`prev_max = MAX(partition column)`; load
-   `[prev_max + 1 - OVERLAP_DAYS, prev_max + 1]`; cold start at `COLD_START_DT`
-   when empty).
-5. For each day in the window, run one transaction: `DELETE` rows matching
-   `MD_DELETE_PREDICATE` for that day, then `INSERT` the day's source read
-   (`bigquery_scan(SCAN_TABLE, filter=...)` in scan mode, or
-   `bigquery_query(GCP_PROJECT_ID, QUERY)` in query mode). Commit on success,
-   roll back on error. Per-phase timing (DELETE, then BigQuery read plus
-   MotherDuck insert) is logged to stdout, which Flight logs capture.
-
-The DELETE plus INSERT per partition is what makes a re-run safe: re-loading a
-day clears its rows first, so you never get duplicates, and a failed day rolls
-back cleanly rather than leaving a half-loaded partition.
-
-## Caveats
-
-- **No credential-free smoke test.** Unlike the `sample_data` templates here,
-  this Flight needs a real BigQuery source: a GCP billing project and a
-  service-account key. There is no public dataset path that exercises the whole
-  flow without credentials.
-- **BigQuery costs money — scan is the cheaper default.** In scan mode,
-  `bigquery_scan` reads through the Storage Read API, billed on the storage-read
-  meter; the `SCAN_FILTER` row restriction on a partitioned column prunes
-  partitions so you only read the days you load. In query mode, `bigquery_query`
-  runs through the Jobs API, billed by bytes scanned (~5–6× the per-byte rate of
-  the storage-read meter) — push the date filter into `QUERY`'s WHERE on a
-  partitioned column so BigQuery still prunes. Either way, a read that scans the
-  full table every run gets expensive fast. Prefer scan unless you need GoogleSQL
-  (see [Which read mode?](#which-read-mode-bigquery_scan-vs-bigquery_query)).
-- **Predicate mirroring is a footgun.** `MD_DELETE_PREDICATE` must select exactly
-  the rows one partition's read produces. If the active read filter (`SCAN_FILTER`
-  or `QUERY`) filters on `event_source` but the DELETE does not, the DELETE clears
-  rows you are not re-loading and you lose data. Keep them in lockstep, and note
-  the quoting difference: the BigQuery-side `SCAN_FILTER`/`QUERY` use double quotes
-  for string literals, the DuckDB-side `MD_DELETE_PREDICATE` uses single quotes.
-- **Watermark and time zones.** The watermark is computed from
-  `MAX(PARTITION_DATE_COLUMN)`, a date, so it is timezone-free as long as the
-  column is a true partition DATE. Scan mode reads the stored DATE column
-  directly. In query mode, if your partition date is derived from a timestamp,
-  derive it the same way in `QUERY` every run (for example `DATE(event_timestamp)`
-  in a consistent zone), or the day boundaries will drift. A deployed Flight runs
-  in UTC; a local `uv run` uses your machine's timezone.
-- **`OVERLAP_DAYS` trades cost for freshness.** A larger overlap heals
-  later-arriving data but re-scans and re-loads more partitions every run. Set it
-  to the longest delay you expect for late rows, no more.
-- **Cold start can be large.** A watermark cold start loads a single day
-  (`COLD_START_DT`). To backfill history, run once with `start_dt`/`end_dt`
-  spanning the range before you rely on the watermark.
 
 ## Security
 

--- a/flight-plans/flight-dive-usage-metrics/README.md
+++ b/flight-plans/flight-dive-usage-metrics/README.md
@@ -38,84 +38,6 @@ It reads Dives read-only and writes only to the target database you configure.
 Everything is driven by Flight config, so you adapt it by setting config values,
 not by editing `flight.py`.
 
-## What you'll adjust
-
-Every knob is a config/env value read at the top of `flight.py`. Set them as
-Flight config, not by editing code.
-
-| Config key | Default | Purpose |
-|---|---|---|
-| `TARGET_DATABASE` | `dive_metrics` | Database that holds the metrics table. Created if missing. Validated as a SQL identifier. |
-| `TARGET_SCHEMA` | `main` | Schema for the metrics table. Created if missing. Validated as a SQL identifier. |
-| `METRICS_TABLE` | `dive_usage_metrics` | Usage metrics table name. A companion `<table>_latest` view exposes the newest run. Validated as a SQL identifier. |
-| `BUILD_RELATIONSHIPS` | `true` | Also build the dependency, co-occurrence, and join-key tables. Set false to produce only the usage metrics. |
-| `EDGES_TABLE` | `dive_object_edges` | Dependency-edge table (one row per Dive-to-object reference). Validated as a SQL identifier. |
-| `COOCCURRENCE_TABLE` | `dive_table_cooccurrence` | Table co-occurrence table (table pairs sharing a statement). Validated as a SQL identifier. |
-| `JOIN_TABLE` | `dive_join_edges` | Mined join-key table (column-to-column edges). Validated as a SQL identifier. |
-| `INCLUDE_ORG_SHARES` | `true` | When true, scan every Dive shared in the organization via `MD_LIST_DIVES(include_org_shares := true)`. When false, scan only the token owner's own Dives. |
-| `DIVE_LIMIT` | (unset) | Optional cap on how many Dives to scan, useful for a quick first run. Unset or `0` means no limit. |
-| `MOTHERDUCK_TOKEN` | (Flight-injected) | Auth. Use a token that can read the Dives you want counted and write `TARGET_DATABASE`. Never put it in config. |
-
-## Questions to answer
-
-- Should the metrics cover every Dive shared in the organization (`INCLUDE_ORG_SHARES=true`), or only the token owner's own Dives?
-- Where should the metrics live (`TARGET_DATABASE`, `TARGET_SCHEMA`, `METRICS_TABLE`), and is that database writable by the chosen token?
-- Which service account token can read the Dives you care about and write the target database?
-- How often should the snapshot refresh (daily or weekly), given how often Dives change?
-- Do you need a quick bounded first run (`DIVE_LIMIT`) before scanning everything?
-
-## Run it
-
-You need a MotherDuck account and an access token. This template has a
-credential-free smoke test: with only a `MOTHERDUCK_TOKEN`, a fresh run produces
-real metrics from your own and your organization's shared Dives. No other
-credentials or setup are needed, because Dives, `MD_LIST_DIVES`, `MD_GET_DIVE`,
-and `json_serialize_sql` are all built into MotherDuck.
-
-```bash
-export MOTHERDUCK_TOKEN=your_token_here
-# optional: bound the first run while you confirm the output
-export DIVE_LIMIT=25
-uv run --with-requirements requirements.txt flight.py
-```
-
-This enumerates the Dives, parses the SQL in each, and writes the metric rows to
-`dive_metrics.main.dive_usage_metrics` (creating the database and schema on first
-run). It prints how many Dives it scanned, how many SQL statements it parsed and
-skipped, and the row count per object type. Query the result:
-
-```sql
-SELECT object_type, object_name, dive_count, reference_count
-FROM dive_metrics.main.dive_usage_metrics_latest
-WHERE object_type = 'table'
-ORDER BY dive_count DESC, reference_count DESC
-LIMIT 20;
-```
-
-### Deploy as a Flight
-
-Create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
-checked in; adapt the arguments to your situation), passing:
-
-- `name`: a Flight name, for example `dive_usage_metrics`
-- `source_code`: the contents of [`flight.py`](flight.py)
-- `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
-- `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
-  override (omit any you are keeping at default)
-
-A MotherDuck token is attached to the Flight automatically and injected at run
-time as `MOTHERDUCK_TOKEN`; no token argument is needed. The run can only count
-Dives that token can read, so deploy from an account that sees them.
-
-Create the Flight without a schedule, trigger one manual run with
-`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
-listed by `MD_FLIGHTS()`), and read the run logs and the `_latest` view to
-confirm the metrics look right. Then add a schedule by updating the Flight's
-`schedule_cron` with `MD_UPDATE_FLIGHT`. A daily run
-(`0 6 * * *`) or weekly run (`0 6 * * 1`) is a reasonable cadence, since Dive
-source SQL changes slowly. Schedule updates are metadata-only and do not create a
-new Flight version.
-
 ## How it works
 
 `flight.py` runs a fixed sequence; the config values only change its inputs:
@@ -173,6 +95,14 @@ ORDER BY dive_count DESC
 LIMIT 20;
 ```
 
+## Questions to answer
+
+- Should the metrics cover every Dive shared in the organization (`INCLUDE_ORG_SHARES=true`), or only the token owner's own Dives?
+- Where should the metrics live (`TARGET_DATABASE`, `TARGET_SCHEMA`, `METRICS_TABLE`), and is that database writable by the chosen token?
+- Which service account token can read the Dives you care about and write the target database?
+- How often should the snapshot refresh (daily or weekly), given how often Dives change?
+- Do you need a quick bounded first run (`DIVE_LIMIT`) before scanning everything?
+
 ## Caveats
 
 - **Tables are limited to fully-qualified names.** Only `database.schema.table`
@@ -216,6 +146,76 @@ LIMIT 20;
   often queries actually run, see `MD_INFORMATION_SCHEMA.QUERY_HISTORY`, but note
   that query history records executed SQL and cannot be attributed back to a
   specific Dive.
+
+## What you'll adjust
+
+Every knob is a config/env value read at the top of `flight.py`. Set them as
+Flight config, not by editing code.
+
+| Config key | Default | Purpose |
+|---|---|---|
+| `TARGET_DATABASE` | `dive_metrics` | Database that holds the metrics table. Created if missing. Validated as a SQL identifier. |
+| `TARGET_SCHEMA` | `main` | Schema for the metrics table. Created if missing. Validated as a SQL identifier. |
+| `METRICS_TABLE` | `dive_usage_metrics` | Usage metrics table name. A companion `<table>_latest` view exposes the newest run. Validated as a SQL identifier. |
+| `BUILD_RELATIONSHIPS` | `true` | Also build the dependency, co-occurrence, and join-key tables. Set false to produce only the usage metrics. |
+| `EDGES_TABLE` | `dive_object_edges` | Dependency-edge table (one row per Dive-to-object reference). Validated as a SQL identifier. |
+| `COOCCURRENCE_TABLE` | `dive_table_cooccurrence` | Table co-occurrence table (table pairs sharing a statement). Validated as a SQL identifier. |
+| `JOIN_TABLE` | `dive_join_edges` | Mined join-key table (column-to-column edges). Validated as a SQL identifier. |
+| `INCLUDE_ORG_SHARES` | `true` | When true, scan every Dive shared in the organization via `MD_LIST_DIVES(include_org_shares := true)`. When false, scan only the token owner's own Dives. |
+| `DIVE_LIMIT` | (unset) | Optional cap on how many Dives to scan, useful for a quick first run. Unset or `0` means no limit. |
+| `MOTHERDUCK_TOKEN` | (Flight-injected) | Auth. Use a token that can read the Dives you want counted and write `TARGET_DATABASE`. Never put it in config. |
+
+## Run it
+
+You need a MotherDuck account and an access token. This template has a
+credential-free smoke test: with only a `MOTHERDUCK_TOKEN`, a fresh run produces
+real metrics from your own and your organization's shared Dives. No other
+credentials or setup are needed, because Dives, `MD_LIST_DIVES`, `MD_GET_DIVE`,
+and `json_serialize_sql` are all built into MotherDuck.
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+# optional: bound the first run while you confirm the output
+export DIVE_LIMIT=25
+uv run --with-requirements requirements.txt flight.py
+```
+
+This enumerates the Dives, parses the SQL in each, and writes the metric rows to
+`dive_metrics.main.dive_usage_metrics` (creating the database and schema on first
+run). It prints how many Dives it scanned, how many SQL statements it parsed and
+skipped, and the row count per object type. Query the result:
+
+```sql
+SELECT object_type, object_name, dive_count, reference_count
+FROM dive_metrics.main.dive_usage_metrics_latest
+WHERE object_type = 'table'
+ORDER BY dive_count DESC, reference_count DESC
+LIMIT 20;
+```
+
+### Deploy as a Flight
+
+Create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments to your situation), passing:
+
+- `name`: a Flight name, for example `dive_usage_metrics`
+- `source_code`: the contents of [`flight.py`](flight.py)
+- `requirements_txt`: the contents of [`requirements.txt`](requirements.txt)
+- `config`: the keys from [What you'll adjust](#what-youll-adjust) you want to
+  override (omit any you are keeping at default)
+
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed. The run can only count
+Dives that token can read, so deploy from an account that sees them.
+
+Create the Flight without a schedule, trigger one manual run with
+`MD_RUN_FLIGHT(flight_id := ...)` (the id is returned by `MD_CREATE_FLIGHT` and
+listed by `MD_FLIGHTS()`), and read the run logs and the `_latest` view to
+confirm the metrics look right. Then add a schedule by updating the Flight's
+`schedule_cron` with `MD_UPDATE_FLIGHT`. A daily run
+(`0 6 * * *`) or weekly run (`0 6 * * 1`) is a reasonable cadence, since Dive
+source SQL changes slowly. Schedule updates are metadata-only and do not create a
+new Flight version.
 
 ## Security
 

--- a/flight-plans/flight-dlt-ingest/README.md
+++ b/flight-plans/flight-dlt-ingest/README.md
@@ -25,6 +25,67 @@ and load it into `flights_demo_dlt.github_repo_stats` in your own account, so a
 fresh deploy produces a successful run. You adapt it by replacing the demo source
 function and pointing the destination at your data.
 
+## How it works
+
+`flight.py` runs a fixed sequence; the config values only change its inputs:
+
+1. Set `HOME=/tmp` (dlt writes working files under `HOME`, and a Flight has a
+   writable `/tmp`) and point the dlt MotherDuck destination at
+   `DESTINATION_DATABASE` through an environment variable, so no token is written
+   anywhere.
+2. Connect to MotherDuck (`md:`) and `CREATE DATABASE IF NOT EXISTS` the
+   destination, because dlt creates the dataset and tables but not the database.
+3. Build a dlt pipeline and `run()` the source with `loader_file_format="parquet"`
+   and the configured write disposition and primary key.
+4. Append one row to the run ledger capturing the dlt load package summary.
+
+## Why this dlt setup
+
+The important default is the load format. For MotherDuck, prefer Parquet loader
+files over row-wise `insert_values`, so larger sources stay on a bulk-loading
+path. The Flight makes that choice explicit with `loader_file_format="parquet"`.
+
+Use this dlt pattern when you want schema evolution, state tracking, merge
+behavior, or a ready-made source connector. If you already have clean Parquet
+files in S3, the [flight-scheduled-s3-ingest](../flight-scheduled-s3-ingest)
+template is simpler. If you only have a few hundred rows of control metadata,
+direct inserts are fine.
+
+## Adapt the pattern
+
+- Replace `repo_rows()` with a dlt source for your API, database, or filesystem.
+- Keep `DESTINATION_DATABASE` pointed at the database where dlt should create the
+  dataset.
+- Use `WRITE_DISPOSITION=merge` with a `PRIMARY_KEY` for entity tables, and
+  `append` for event streams.
+- Keep `loader_file_format="parquet"` unless you have measured a reason to change
+  it.
+- Lower dlt load workers if a source or network path is unreliable. See the
+  [dlt MotherDuck destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/motherduck).
+
+## Questions to answer
+
+- What is the real source: which dlt source, API, database, or filesystem replaces `repo_rows()`?
+- Target MotherDuck database and dataset (`DESTINATION_DATABASE`, `DATASET_NAME`); is letting the Flight create the database acceptable?
+- Load behavior: `merge` with a `PRIMARY_KEY` for entity tables, or `append` for event streams?
+- Which service account token, and how are any source credentials kept out of config?
+- What schedule (cron) should it run on?
+
+## Caveats
+
+- **dlt does not create the database.** It creates the dataset (schema) and tables,
+  so the Flight pre-creates `DESTINATION_DATABASE` with `CREATE DATABASE IF NOT EXISTS`.
+- **`merge` needs a primary key.** With `WRITE_DISPOSITION=merge`, set `PRIMARY_KEY`
+  to the column that identifies a row; otherwise use `append` or `replace`.
+- **Keep source credentials out of config.** Flight config is for non-secret
+  values. Add a private source's credentials as a MotherDuck **Flights secret**
+  (the simplest way is the MotherDuck UI at
+  [Settings > Secrets](https://app.motherduck.com/settings/secrets), or
+  `CREATE SECRET ... (TYPE flights, ...)` from the DuckDB client), which the
+  runtime injects as env vars you read with `os.environ`.
+- **Keep the token out of config.** The runtime attaches a MotherDuck token and
+  injects it as `MOTHERDUCK_TOKEN`; never place a token in `config`.
+
 ## What you'll adjust
 
 Every knob is a config/env value read at the top of `flight.py`. Set them as
@@ -42,14 +103,6 @@ Flight config, not by editing code. The demo source itself lives in the
 | `GITHUB_REPOS` | `duckdb/duckdb,motherduckdb/motherduck-docs,dlt-hub/dlt` | Comma-separated repos the demo source fetches. |
 | `RUN_LEDGER_TABLE` | `dlt_ingest_runs` | Audit table in the database's `main` schema. Validated as a SQL identifier. |
 | `MOTHERDUCK_TOKEN` | (Flight-injected) | Auth. Select a token on the Flight; never put it in config. |
-
-## Questions to answer
-
-- What is the real source: which dlt source, API, database, or filesystem replaces `repo_rows()`?
-- Target MotherDuck database and dataset (`DESTINATION_DATABASE`, `DATASET_NAME`); is letting the Flight create the database acceptable?
-- Load behavior: `merge` with a `PRIMARY_KEY` for entity tables, or `append` for event streams?
-- Which service account token, and how are any source credentials kept out of config?
-- What schedule (cron) should it run on?
 
 ## Run it
 
@@ -91,59 +144,6 @@ row appear. Once the manual run is green, add a daily schedule (`15 7 * * *`,
 07:15 UTC, is a reasonable default) by updating the Flight's `schedule_cron` with
 `MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
 Flight version.
-
-## How it works
-
-`flight.py` runs a fixed sequence; the config values only change its inputs:
-
-1. Set `HOME=/tmp` (dlt writes working files under `HOME`, and a Flight has a
-   writable `/tmp`) and point the dlt MotherDuck destination at
-   `DESTINATION_DATABASE` through an environment variable, so no token is written
-   anywhere.
-2. Connect to MotherDuck (`md:`) and `CREATE DATABASE IF NOT EXISTS` the
-   destination, because dlt creates the dataset and tables but not the database.
-3. Build a dlt pipeline and `run()` the source with `loader_file_format="parquet"`
-   and the configured write disposition and primary key.
-4. Append one row to the run ledger capturing the dlt load package summary.
-
-## Why this dlt setup
-
-The important default is the load format. For MotherDuck, prefer Parquet loader
-files over row-wise `insert_values`, so larger sources stay on a bulk-loading
-path. The Flight makes that choice explicit with `loader_file_format="parquet"`.
-
-Use this dlt pattern when you want schema evolution, state tracking, merge
-behavior, or a ready-made source connector. If you already have clean Parquet
-files in S3, the [flight-scheduled-s3-ingest](../flight-scheduled-s3-ingest)
-template is simpler. If you only have a few hundred rows of control metadata,
-direct inserts are fine.
-
-## Adapt the pattern
-
-- Replace `repo_rows()` with a dlt source for your API, database, or filesystem.
-- Keep `DESTINATION_DATABASE` pointed at the database where dlt should create the
-  dataset.
-- Use `WRITE_DISPOSITION=merge` with a `PRIMARY_KEY` for entity tables, and
-  `append` for event streams.
-- Keep `loader_file_format="parquet"` unless you have measured a reason to change
-  it.
-- Lower dlt load workers if a source or network path is unreliable. See the
-  [dlt MotherDuck destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/motherduck).
-
-## Caveats
-
-- **dlt does not create the database.** It creates the dataset (schema) and tables,
-  so the Flight pre-creates `DESTINATION_DATABASE` with `CREATE DATABASE IF NOT EXISTS`.
-- **`merge` needs a primary key.** With `WRITE_DISPOSITION=merge`, set `PRIMARY_KEY`
-  to the column that identifies a row; otherwise use `append` or `replace`.
-- **Keep source credentials out of config.** Flight config is for non-secret
-  values. Add a private source's credentials as a MotherDuck **Flights secret**
-  (the simplest way is the MotherDuck UI at
-  [Settings > Secrets](https://app.motherduck.com/settings/secrets), or
-  `CREATE SECRET ... (TYPE flights, ...)` from the DuckDB client), which the
-  runtime injects as env vars you read with `os.environ`.
-- **Keep the token out of config.** The runtime attaches a MotherDuck token and
-  injects it as `MOTHERDUCK_TOKEN`; never place a token in `config`.
 
 ## Security
 

--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -26,6 +26,74 @@ the top of `flight.py` (much like you replace `repo_rows()` in
 and fires one Slack message. That doubles as a built-in test that your webhook is
 wired up. Swap `CHECKS` for your own tables before you add a schedule.
 
+## How it works
+
+`flight.py` runs a fixed sequence; only the `CHECKS` list changes its inputs:
+
+1. Connect to MotherDuck (`md:`).
+2. For each check, run `SELECT max(column), date_diff('hour', max(column), now())`
+   and assign `pass` / `warn` / `error` from the two thresholds. The comparison
+   is done in SQL against the runtime clock, so it follows the runtime timezone
+   (see [Time zones](#time-zones)). A missing table/column or an empty table is
+   recorded as `error` for that one check, not raised, so a single typo does not
+   hide the other checks.
+3. Write one ledger row per check to `RESULTS_TABLE` (its database and schema are
+   created on first run, since `sample_data` is read-only).
+4. Print the report. If any check is at or above `ALERT_LEVEL` and
+   `SLACK_WEBHOOK_URL` is set, POST a Slack Block Kit message listing each stale
+   table with its lag and severity.
+
+## Time zones
+
+Freshness is `now() - MAX(column)`, computed in the database, so the comparison
+uses the **runtime's clock and timezone**. A deployed Flight runs in **UTC**; a
+local `uv run` uses your machine's timezone. Two consequences:
+
+- **`TIMESTAMPTZ` columns are unambiguous.** They carry an offset, so the age and
+  the stored `max_timestamp` are correct no matter where the code runs. Prefer
+  these.
+- **Naive `TIMESTAMP` columns are read in the runtime timezone.** A value like
+  `2024-01-01 09:00:00` with no offset is treated as 09:00 *in the runtime tz*
+  (UTC on a Flight). If your naive timestamps are actually stored in another
+  timezone, the computed age is off by that UTC offset, and the `max_timestamp`
+  written to the ledger reflects the runtime tz. Deploy as a Flight (UTC) for
+  consistent results, or store source timestamps as `TIMESTAMPTZ`.
+
+**Why `pytz` is a dependency.** Reading a `TIMESTAMPTZ` value back into Python as a
+tz-aware `datetime` requires `pytz`. The duckdb wheel ships with no required
+dependencies (timezone math inside the engine uses the bundled ICU extension), so
+`pytz` is not installed automatically; without it, a check on a `TIMESTAMPTZ`
+column fails with `Required module 'pytz' failed to import`. It is pinned next to
+`duckdb` in `requirements.txt` so checks work on tz-aware columns.
+
+## Questions to answer
+
+- Which tables need monitoring, and which column on each records when its rows arrive (load time, event time, ingest time)?
+- What `warn`/`error` age thresholds match each table's expected update cadence?
+- Should the alert fire on `warn`, or only on `error`?
+- Which Slack channel receives the alert, and is its Incoming Webhook stored as a MotherDuck secret?
+- Which service account token can read the checked tables and write the ledger?
+- What schedule (cron, UTC) matches how often the data should refresh?
+
+## Caveats
+
+- **The default `CHECKS` always alert.** `sample_data` is a read-only ~2022
+  snapshot, so both default checks report `error` every run. This is intentional:
+  it proves a fresh deploy can reach Slack. Replace `CHECKS` with your own tables
+  before adding a schedule, or you will get a Slack message on every run.
+- **Pick the right column.** Freshness is `MAX(column)`. Use the column that
+  records when a row landed (load, ingest, or event time), not an unrelated date.
+- **Failures degrade per check.** A missing table/column or an empty table is
+  recorded as `error` for that check with the reason, rather than aborting the run.
+- **A broken webhook fails the run.** A configured `SLACK_WEBHOOK_URL` that returns
+  an error raises after the ledger is written, so a broken alert path shows up as a
+  FAILED run instead of silently dropping the alert.
+- **The ledger needs a writable database.** `RESULTS_TABLE` must live in a database
+  you can write to; the Flight creates `flights_demo` if it is missing. Set
+  `RESULTS_TABLE = ""` to skip the ledger.
+- **Keep secrets out of code.** Put the webhook in a MotherDuck secret and select a
+  token on the Flight; never hard-code either.
+
 ## What you'll adjust
 
 The freshness checks live in the `CHECKS` list at the top of `flight.py`; two
@@ -42,15 +110,6 @@ and the MotherDuck token come from outside the code.
 | `RESULTS_TABLE` | top of `flight.py` | `flights_demo.main.freshness_check_runs` | Audit ledger target as `database.schema.table`. Must be a writable database. `""` disables the ledger. |
 | `SLACK_WEBHOOK_URL` | Flight secret / env var | (unset) | Slack Incoming Webhook URL. Provide it through a MotherDuck secret, never in code. As a Flight the secret arrives as `<secret_name>_SLACK_WEBHOOK_URL`; `flight.py` resolves either name. Unset → the run prints the report and skips Slack. |
 | `MOTHERDUCK_TOKEN` | Flight-injected | (Flight-injected) | Auth. Select a token on the Flight; never hard-code it. |
-
-## Questions to answer
-
-- Which tables need monitoring, and which column on each records when its rows arrive (load time, event time, ingest time)?
-- What `warn`/`error` age thresholds match each table's expected update cadence?
-- Should the alert fire on `warn`, or only on `error`?
-- Which Slack channel receives the alert, and is its Incoming Webhook stored as a MotherDuck secret?
-- Which service account token can read the checked tables and write the ledger?
-- What schedule (cron, UTC) matches how often the data should refresh?
 
 ## Run it
 
@@ -146,65 +205,6 @@ Then edit `CHECKS` to your real tables and add a schedule (for example
 `0 * * * *`, hourly) by updating the Flight's `schedule_cron` with
 `MD_UPDATE_FLIGHT`. Schedule updates are metadata-only and do not create a new
 Flight version.
-
-## How it works
-
-`flight.py` runs a fixed sequence; only the `CHECKS` list changes its inputs:
-
-1. Connect to MotherDuck (`md:`).
-2. For each check, run `SELECT max(column), date_diff('hour', max(column), now())`
-   and assign `pass` / `warn` / `error` from the two thresholds. The comparison
-   is done in SQL against the runtime clock, so it follows the runtime timezone
-   (see [Time zones](#time-zones)). A missing table/column or an empty table is
-   recorded as `error` for that one check, not raised, so a single typo does not
-   hide the other checks.
-3. Write one ledger row per check to `RESULTS_TABLE` (its database and schema are
-   created on first run, since `sample_data` is read-only).
-4. Print the report. If any check is at or above `ALERT_LEVEL` and
-   `SLACK_WEBHOOK_URL` is set, POST a Slack Block Kit message listing each stale
-   table with its lag and severity.
-
-## Time zones
-
-Freshness is `now() - MAX(column)`, computed in the database, so the comparison
-uses the **runtime's clock and timezone**. A deployed Flight runs in **UTC**; a
-local `uv run` uses your machine's timezone. Two consequences:
-
-- **`TIMESTAMPTZ` columns are unambiguous.** They carry an offset, so the age and
-  the stored `max_timestamp` are correct no matter where the code runs. Prefer
-  these.
-- **Naive `TIMESTAMP` columns are read in the runtime timezone.** A value like
-  `2024-01-01 09:00:00` with no offset is treated as 09:00 *in the runtime tz*
-  (UTC on a Flight). If your naive timestamps are actually stored in another
-  timezone, the computed age is off by that UTC offset, and the `max_timestamp`
-  written to the ledger reflects the runtime tz. Deploy as a Flight (UTC) for
-  consistent results, or store source timestamps as `TIMESTAMPTZ`.
-
-**Why `pytz` is a dependency.** Reading a `TIMESTAMPTZ` value back into Python as a
-tz-aware `datetime` requires `pytz`. The duckdb wheel ships with no required
-dependencies (timezone math inside the engine uses the bundled ICU extension), so
-`pytz` is not installed automatically; without it, a check on a `TIMESTAMPTZ`
-column fails with `Required module 'pytz' failed to import`. It is pinned next to
-`duckdb` in `requirements.txt` so checks work on tz-aware columns.
-
-## Caveats
-
-- **The default `CHECKS` always alert.** `sample_data` is a read-only ~2022
-  snapshot, so both default checks report `error` every run. This is intentional:
-  it proves a fresh deploy can reach Slack. Replace `CHECKS` with your own tables
-  before adding a schedule, or you will get a Slack message on every run.
-- **Pick the right column.** Freshness is `MAX(column)`. Use the column that
-  records when a row landed (load, ingest, or event time), not an unrelated date.
-- **Failures degrade per check.** A missing table/column or an empty table is
-  recorded as `error` for that check with the reason, rather than aborting the run.
-- **A broken webhook fails the run.** A configured `SLACK_WEBHOOK_URL` that returns
-  an error raises after the ledger is written, so a broken alert path shows up as a
-  FAILED run instead of silently dropping the alert.
-- **The ledger needs a writable database.** `RESULTS_TABLE` must live in a database
-  you can write to; the Flight creates `flights_demo` if it is missing. Set
-  `RESULTS_TABLE = ""` to skip the ledger.
-- **Keep secrets out of code.** Put the webhook in a MotherDuck secret and select a
-  token on the Flight; never hard-code either.
 
 ## Security
 

--- a/flight-plans/flight-postgres-ingest/README.md
+++ b/flight-plans/flight-postgres-ingest/README.md
@@ -30,6 +30,50 @@ Full refresh is the simplest correct choice for mutable tables;
 If you have very large tables (billions of rows), consider incremental/append/CDC
 and use a different Flight template or modify this one heavily.
 
+## How it works
+
+`flight.py` runs a fixed sequence:
+
+1. **Connect.** Set `motherduck_host` if `MOTHERDUCK_HOST` given, `duckdb.connect("md:")`.
+2. **Attach Postgres read-only.** Export `pg_*` to libpq env vars, `INSTALL`/`LOAD postgres`, `ATTACH '' AS pg (TYPE postgres, READ_ONLY)`. `READ_ONLY` lets the extension parallelize reads; the empty connection string keeps the password in env, never in SQL.
+3. **Ensure target.** `CREATE DATABASE IF NOT EXISTS` plus creating the `main.flight_tracker` audit table.
+4. **Discover base tables** List base tables (`information_schema.tables WHERE table_type = 'BASE TABLE'` via `postgres_query`), keep those passing the gates.
+5. **Load each table.** Pre-create schemas, then per table run `CREATE OR REPLACE ... AS SELECT *` under a tenacity retry (jittered exponential backoff, transient errors). Log a `flight_tracker` row on success; on failure after retries, log and continue (per-table isolation). Exit non-zero if anything failed.
+
+## Questions to answer
+
+- Postgres source: host, port, database, user, SSL mode — and which password? Enter as a MotherDuck secret.
+- Which schemas/tables to mirror: everything non-system, one schema, or an explicit allow/deny list?
+- Which `TARGET_DATABASE` should receive the mirror?
+- Is a full refresh per run acceptable given table sizes? (See [Caveats](#caveats).)
+- What schedule (cron, UTC) matches source change rate and freshness needs?
+- Any exotic Postgres column types that the DuckDB Postgres extension can't map that should be excluded?
+
+## Caveats
+
+- **Full refresh re-reads the whole table every run.** Cost scales with table
+  size, not change volume. Updates and deletes are reflected, but a table
+  **dropped** from the source is NOT dropped from the target — remove it yourself
+  or recreate the target database. For very large/slowly-changing tables, an
+  incremental pattern is cheaper.
+- **The upload is single threaded and sequential by design.** Testing a ~90M-row database showed
+  no improvement when parallelizing the load of multiple large tables.
+  Testing also showed that adjusting DuckDB `threads`, `pg_pages_per_task`,
+  `pg_connection_limit`, `pg_pool_max_connections`, and using multiple Python threads all
+  leave total time unchanged - hence the simple sequential loop.
+  If performance is critical, consider the added dependency of an AWS S3 bucket in your MotherDuck region and
+  staging Postgres data in Parquet in S3 and ingest server-side
+  (`read_parquet('s3://…')` runs in the MotherDuck duckling).
+  This Flight avoids the dependency on an S3 bucket to keep things simpler.
+- **`SELECT *` relies on the extension's type mapping.** Exotic Postgres types
+  (custom enums, ranges, `hstore`, composite arrays) may surface as `VARCHAR` or
+  error — exclude such tables or fork `load_table` to project columns.
+- **Base tables only.** Discovery filters `table_type = 'BASE TABLE'`; views,
+  materialized views, and foreign tables are skipped by design.
+- **Client-side extension.** The Postgres scan runs in the Flight container and rows upload to MotherDuck from there.
+- **Old tables are not dropped.** The target database is not cleared out at the start of the run,
+  so old tables can persist. A separate command would be required to clear out the target database.
+
 ## What you'll adjust
 
 No code edits are required (code edits are optional). 
@@ -61,15 +105,6 @@ Two gotchas with the `pg` secret:
   `pg_HOST`), which `flight.py` reads via `PG_PARAMS`.
 - **Code edits are required to use a name other than `pg`.** DuckDB lowercases the secret name into the prefix.
   Rename the secret only if you also change `SECRET_NAME` in `flight.py`.
-
-## Questions to answer
-
-- Postgres source: host, port, database, user, SSL mode — and which password? Enter as a MotherDuck secret.
-- Which schemas/tables to mirror: everything non-system, one schema, or an explicit allow/deny list?
-- Which `TARGET_DATABASE` should receive the mirror?
-- Is a full refresh per run acceptable given table sizes? (See [Caveats](#caveats).)
-- What schedule (cron, UTC) matches source change rate and freshness needs?
-- Any exotic Postgres column types that the DuckDB Postgres extension can't map that should be excluded?
 
 ## Run it
 
@@ -136,41 +171,6 @@ Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
 id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`), and confirm
 `<TARGET_DATABASE>.main.flight_tracker` has one row per table. 
 Get feedback from the user about whether or not a schedule is desired and what it should be.
-
-## How it works
-
-`flight.py` runs a fixed sequence:
-
-1. **Connect.** Set `motherduck_host` if `MOTHERDUCK_HOST` given, `duckdb.connect("md:")`.
-2. **Attach Postgres read-only.** Export `pg_*` to libpq env vars, `INSTALL`/`LOAD postgres`, `ATTACH '' AS pg (TYPE postgres, READ_ONLY)`. `READ_ONLY` lets the extension parallelize reads; the empty connection string keeps the password in env, never in SQL.
-3. **Ensure target.** `CREATE DATABASE IF NOT EXISTS` plus creating the `main.flight_tracker` audit table.
-4. **Discover base tables** List base tables (`information_schema.tables WHERE table_type = 'BASE TABLE'` via `postgres_query`), keep those passing the gates.
-5. **Load each table.** Pre-create schemas, then per table run `CREATE OR REPLACE ... AS SELECT *` under a tenacity retry (jittered exponential backoff, transient errors). Log a `flight_tracker` row on success; on failure after retries, log and continue (per-table isolation). Exit non-zero if anything failed.
-
-## Caveats
-
-- **Full refresh re-reads the whole table every run.** Cost scales with table
-  size, not change volume. Updates and deletes are reflected, but a table
-  **dropped** from the source is NOT dropped from the target — remove it yourself
-  or recreate the target database. For very large/slowly-changing tables, an
-  incremental pattern is cheaper.
-- **The upload is single threaded and sequential by design.** Testing a ~90M-row database showed 
-  no improvement when parallelizing the load of multiple large tables.
-  Testing also showed that adjusting DuckDB `threads`, `pg_pages_per_task`,
-  `pg_connection_limit`, `pg_pool_max_connections`, and using multiple Python threads all
-  leave total time unchanged - hence the simple sequential loop. 
-  If performance is critical, consider the added dependency of an AWS S3 bucket in your MotherDuck region and 
-  staging Postgres data in Parquet in S3 and ingest server-side 
-  (`read_parquet('s3://…')` runs in the MotherDuck duckling).
-  This Flight avoids the dependency on an S3 bucket to keep things simpler.
-- **`SELECT *` relies on the extension's type mapping.** Exotic Postgres types
-  (custom enums, ranges, `hstore`, composite arrays) may surface as `VARCHAR` or
-  error — exclude such tables or fork `load_table` to project columns.
-- **Base tables only.** Discovery filters `table_type = 'BASE TABLE'`; views,
-  materialized views, and foreign tables are skipped by design.
-- **Client-side extension.** The Postgres scan runs in the Flight container and rows upload to MotherDuck from there.
-- **Old tables are not dropped.** The target database is not cleared out at the start of the run, 
-  so old tables can persist. A separate command would be required to clear out the target database.
 
 ## Security
 

--- a/flight-plans/flight-provision-user-databases/README.md
+++ b/flight-plans/flight-provision-user-databases/README.md
@@ -28,6 +28,50 @@ with real MotherDuck usernames and set `DRY_RUN=false` to provision for real.
 Everything is driven by Flight config, so you adapt it by setting config values,
 not by editing `flight.py`.
 
+## How it works
+
+`flight.py` runs a fixed sequence; the config values only change its inputs:
+
+1. Connect to MotherDuck (`md:`), create `PROVISION_DATABASE` and its schema, seed
+   the demo control table if it does not exist, and create the ledger table.
+2. Read the users ordered by email.
+3. For each **active** user, derive `DATABASE_PREFIX + slug(email)` and create the
+   database, a `USER_SCHEMA` schema, and a `profile` table, then create a
+   restricted share (`ACCESS RESTRICTED, VISIBILITY HIDDEN, UPDATE AUTOMATIC`) and
+   grant read access to the username.
+4. For each **inactive** user, revoke read access on that user's share.
+5. Append one ledger row per user, including whether the run was a dry run.
+
+When `DRY_RUN` is true, steps 3 and 4 only log the intended action; the ledger
+still records the plan, so you can review exactly what a live run would do.
+
+## Questions to answer
+
+- Which control table lists the users, and does it have `email`, `segment`, and `active` columns (`USERS_TABLE`, `PROVISION_DATABASE`, `PROVISION_SCHEMA`)?
+- Are the `email` values valid MotherDuck usernames in the same sharing scope?
+- How should per-user databases and shares be named (`DATABASE_PREFIX`, `SHARE_SUFFIX`)?
+- What does each user's database need beyond the demo profile table (`USER_SCHEMA` plus your own tables)?
+- Which admin or service account token should own the created resources?
+- Run on demand, or on a schedule once the control table is trusted?
+- Validating the plan first (`DRY_RUN=true`), or ready to provision for real (`DRY_RUN=false`)?
+
+## Caveats
+
+- **These are account-level resources.** The databases and shares are visible
+  beyond `PROVISION_DATABASE`. Treat this as an admin workflow with a scoped token.
+- **`DRY_RUN` defaults to true on purpose.** A first deploy never creates shares
+  for placeholder users. Replace the seeded demo users with real MotherDuck
+  usernames before setting `DRY_RUN=false`.
+- **Deprovisioning is revoke-only.** Inactive users lose share access, but their
+  database is not dropped. Dropping user databases is a separate policy decision.
+- **Usernames must be valid.** A grant or revoke for an address that is not a
+  MotherDuck user in the same sharing scope is skipped and logged, not fatal, so
+  one bad row does not stop the run.
+- **Re-running is idempotent for resources, not the ledger.** Active users use
+  `IF NOT EXISTS`/`OR REPLACE`, but the ledger appends one row per user per run.
+- **Keep the token out of config.** Select a token on the Flight so
+  `MOTHERDUCK_TOKEN` is injected at runtime; do not place it in `config`.
+
 ## What you'll adjust
 
 Every knob is a config/env value read at the top of `flight.py`. Set them as
@@ -44,16 +88,6 @@ Flight config, not by editing code.
 | `SHARE_SUFFIX` | `_share` | Suffix for each per-user share (`<database><suffix>`). Validated as a SQL identifier. |
 | `USER_SCHEMA` | `app` | Schema created inside each user database for the profile table. Validated as a SQL identifier. |
 | `MOTHERDUCK_TOKEN` | (Flight-injected) | Auth. Use an admin or service account token allowed to create databases and shares and to grant/revoke. Never put it in config. |
-
-## Questions to answer
-
-- Which control table lists the users, and does it have `email`, `segment`, and `active` columns (`USERS_TABLE`, `PROVISION_DATABASE`, `PROVISION_SCHEMA`)?
-- Are the `email` values valid MotherDuck usernames in the same sharing scope?
-- How should per-user databases and shares be named (`DATABASE_PREFIX`, `SHARE_SUFFIX`)?
-- What does each user's database need beyond the demo profile table (`USER_SCHEMA` plus your own tables)?
-- Which admin or service account token should own the created resources?
-- Run on demand, or on a schedule once the control table is trusted?
-- Validating the plan first (`DRY_RUN=true`), or ready to provision for real (`DRY_RUN=false`)?
 
 ## Run it
 
@@ -99,40 +133,6 @@ the seeded demo rows), set `DRY_RUN=false`, and run again to provision. Add a
 schedule by updating the Flight's `schedule_cron` with `MD_UPDATE_FLIGHT` only
 once you trust the control table; schedule updates are metadata-only and do not
 create a new Flight version.
-
-## How it works
-
-`flight.py` runs a fixed sequence; the config values only change its inputs:
-
-1. Connect to MotherDuck (`md:`), create `PROVISION_DATABASE` and its schema, seed
-   the demo control table if it does not exist, and create the ledger table.
-2. Read the users ordered by email.
-3. For each **active** user, derive `DATABASE_PREFIX + slug(email)` and create the
-   database, a `USER_SCHEMA` schema, and a `profile` table, then create a
-   restricted share (`ACCESS RESTRICTED, VISIBILITY HIDDEN, UPDATE AUTOMATIC`) and
-   grant read access to the username.
-4. For each **inactive** user, revoke read access on that user's share.
-5. Append one ledger row per user, including whether the run was a dry run.
-
-When `DRY_RUN` is true, steps 3 and 4 only log the intended action; the ledger
-still records the plan, so you can review exactly what a live run would do.
-
-## Caveats
-
-- **These are account-level resources.** The databases and shares are visible
-  beyond `PROVISION_DATABASE`. Treat this as an admin workflow with a scoped token.
-- **`DRY_RUN` defaults to true on purpose.** A first deploy never creates shares
-  for placeholder users. Replace the seeded demo users with real MotherDuck
-  usernames before setting `DRY_RUN=false`.
-- **Deprovisioning is revoke-only.** Inactive users lose share access, but their
-  database is not dropped. Dropping user databases is a separate policy decision.
-- **Usernames must be valid.** A grant or revoke for an address that is not a
-  MotherDuck user in the same sharing scope is skipped and logged, not fatal, so
-  one bad row does not stop the run.
-- **Re-running is idempotent for resources, not the ledger.** Active users use
-  `IF NOT EXISTS`/`OR REPLACE`, but the ledger appends one row per user per run.
-- **Keep the token out of config.** Select a token on the Flight so
-  `MOTHERDUCK_TOKEN` is injected at runtime; do not place it in `config`.
 
 ## Security
 

--- a/flight-plans/flight-scheduled-s3-ingest/README.md
+++ b/flight-plans/flight-scheduled-s3-ingest/README.md
@@ -25,6 +25,55 @@ stats (partitioned by `year`) and build `flights_demo.main.duckdb_pypi_downloads
 in your own account, so a fresh deploy produces a successful run you can then
 point at your own data.
 
+## How it works
+
+`flight.py` runs a fixed sequence; the config values only change its inputs:
+
+1. Connect to MotherDuck (`md:`) and `CREATE DATABASE`/`CREATE SCHEMA IF NOT EXISTS`
+   for the destination, so the Flight owns everything it needs.
+2. Create the destination once with `CREATE TABLE IF NOT EXISTS ... AS SELECT * ... LIMIT 0`,
+   which infers the destination columns from the source without reading rows.
+3. `DELETE` the target partition, then `INSERT` it back by reading the source with
+   `hive_partitioning = true` and `WHERE PARTITION_COLUMN = LOAD_PARTITION`. The
+   filter on the partition column is what lets DuckDB prune to a single folder.
+4. Count the refreshed rows and append one row to the run ledger.
+
+The default load is a `SELECT *` pass-through, so it works for any partitioned
+Parquet with no code changes. To shape the data instead, replace the marked
+`SELECT *` in the `INSERT` with your own projection or aggregation, keeping the
+partition column so the incremental replace still lines up.
+
+## Questions to answer
+
+- Which partitioned source, and what is its partition key (`SOURCE_GLOB`, `PARTITION_COLUMN`)?
+- Which partition should each scheduled run refresh (`LOAD_PARTITION`, default current year)?
+- Target MotherDuck database, schema, and table (`DESTINATION_*`); is letting the Flight create them acceptable?
+- Is the source public, or does a private bucket need a MotherDuck S3 secret first?
+- Which service account token should the Flight use for a scheduled workload?
+- What schedule (cron) should it run on?
+
+## Caveats
+
+- **Pruning depends on a direct partition filter.** The speedup comes from
+  comparing the raw `PARTITION_COLUMN` to `LOAD_PARTITION`. Wrapping the column in
+  a function (for example `CAST(year AS VARCHAR)`) can defeat pruning and read
+  every folder.
+- **The destination schema is inferred on the first run.** If you later change the
+  source columns, they may not match the existing table. Drop and recreate the
+  destination, or migrate it, when the shape changes.
+- **Numeric partition values are integers.** A digit-only `LOAD_PARTITION` is bound
+  as an integer so it matches a numeric Hive column. Pass a non-numeric value for
+  string partitions (for example a region code).
+- **Private buckets need a secret.** The default dataset is public. Point
+  `SOURCE_GLOB` at a private bucket only after adding a MotherDuck **S3 secret**
+  for it: the simplest way is the MotherDuck UI at
+  [Settings > Secrets](https://app.motherduck.com/settings/secrets), or
+  `CREATE SECRET ... (TYPE S3, ...)` from the DuckDB client. It must be available
+  to the Flight's token. (This is an S3 secret on the account, not a Flights
+  secret: it is read by the engine, not injected as an env var.)
+- **Keep the token out of config.** Select a token on the Flight so
+  `MOTHERDUCK_TOKEN` is injected at runtime; do not place it in `config`.
+
 ## What you'll adjust
 
 Every knob is a config/env value read at the top of `flight.py`. Set them as
@@ -41,15 +90,6 @@ Flight config, not by editing code.
 | `HIVE_PARTITIONING` | `true` | Turn `key=value` folder names into columns. |
 | `RUN_LEDGER_TABLE` | `ingest_runs` | Audit table that records one row per run. Validated as a SQL identifier. |
 | `MOTHERDUCK_TOKEN` | (Flight-injected) | Auth. Select a token on the Flight; never put it in config. |
-
-## Questions to answer
-
-- Which partitioned source, and what is its partition key (`SOURCE_GLOB`, `PARTITION_COLUMN`)?
-- Which partition should each scheduled run refresh (`LOAD_PARTITION`, default current year)?
-- Target MotherDuck database, schema, and table (`DESTINATION_*`); is letting the Flight create them acceptable?
-- Is the source public, or does a private bucket need a MotherDuck S3 secret first?
-- Which service account token should the Flight use for a scheduled workload?
-- What schedule (cron) should it run on?
 
 ## Run it
 
@@ -92,46 +132,6 @@ historical files. Once the manual run is green, add a daily schedule (the source
 updates daily; `30 6 * * *`, 06:30 UTC, is a reasonable default) by updating the
 Flight's `schedule_cron` with `MD_UPDATE_FLIGHT`. Schedule updates are
 metadata-only and do not create a new Flight version.
-
-## How it works
-
-`flight.py` runs a fixed sequence; the config values only change its inputs:
-
-1. Connect to MotherDuck (`md:`) and `CREATE DATABASE`/`CREATE SCHEMA IF NOT EXISTS`
-   for the destination, so the Flight owns everything it needs.
-2. Create the destination once with `CREATE TABLE IF NOT EXISTS ... AS SELECT * ... LIMIT 0`,
-   which infers the destination columns from the source without reading rows.
-3. `DELETE` the target partition, then `INSERT` it back by reading the source with
-   `hive_partitioning = true` and `WHERE PARTITION_COLUMN = LOAD_PARTITION`. The
-   filter on the partition column is what lets DuckDB prune to a single folder.
-4. Count the refreshed rows and append one row to the run ledger.
-
-The default load is a `SELECT *` pass-through, so it works for any partitioned
-Parquet with no code changes. To shape the data instead, replace the marked
-`SELECT *` in the `INSERT` with your own projection or aggregation, keeping the
-partition column so the incremental replace still lines up.
-
-## Caveats
-
-- **Pruning depends on a direct partition filter.** The speedup comes from
-  comparing the raw `PARTITION_COLUMN` to `LOAD_PARTITION`. Wrapping the column in
-  a function (for example `CAST(year AS VARCHAR)`) can defeat pruning and read
-  every folder.
-- **The destination schema is inferred on the first run.** If you later change the
-  source columns, they may not match the existing table. Drop and recreate the
-  destination, or migrate it, when the shape changes.
-- **Numeric partition values are integers.** A digit-only `LOAD_PARTITION` is bound
-  as an integer so it matches a numeric Hive column. Pass a non-numeric value for
-  string partitions (for example a region code).
-- **Private buckets need a secret.** The default dataset is public. Point
-  `SOURCE_GLOB` at a private bucket only after adding a MotherDuck **S3 secret**
-  for it: the simplest way is the MotherDuck UI at
-  [Settings > Secrets](https://app.motherduck.com/settings/secrets), or
-  `CREATE SECRET ... (TYPE S3, ...)` from the DuckDB client. It must be available
-  to the Flight's token. (This is an S3 secret on the account, not a Flights
-  secret: it is read by the engine, not injected as an env var.)
-- **Keep the token out of config.** Select a token on the Flight so
-  `MOTHERDUCK_TOKEN` is injected at runtime; do not place it in `config`.
 
 ## Security
 

--- a/flight-plans/flight-snowflake-ingest/README.md
+++ b/flight-plans/flight-snowflake-ingest/README.md
@@ -32,6 +32,82 @@ move in one run). There is no first-class DuckDB `snowflake` extension, so the
 path is `snowflake-connector-python` (Arrow fetch) into a DuckDB-registered Arrow
 object, then a CTAS into `md:`.
 
+## How it works
+
+`flight.py` connects to MotherDuck (`md:`), creates `TARGET_DB`, the control
+schema, and the target schema if missing, then runs one or both phases:
+
+1. **DISCOVER.** Determine the databases in scope: just `SNOWFLAKE_DATABASE` when
+   set, otherwise every database the connection can see (via `SHOW TERSE
+   DATABASES`). For each, query its `INFORMATION_SCHEMA.TABLES` (optionally
+   filtered to `SNOWFLAKE_SCHEMA`), listing `table_catalog, table_schema,
+   table_name, row_count, bytes, table_type`, and skip any database the role
+   cannot read. Write the combined result to the inventory control table with an
+   added `selected BOOLEAN` (defaulted to `table_type = 'BASE TABLE'`) and a
+   `discovered_at` timestamp. The write is a `CREATE OR REPLACE`, so re-discovery
+   refreshes the inventory.
+2. **MOVE.** Read the rows where `selected` is true. For each, run
+   `SELECT * FROM <db>.<schema>.<table>` in Snowflake, fetch the result as one
+   Arrow table with `cursor.fetch_arrow_all()`, register that Arrow object with
+   the DuckDB connection, and `CREATE OR REPLACE TABLE
+   <TARGET_DB>.<TARGET_SCHEMA>.<table> AS SELECT * FROM <arrow>`. Each table is
+   idempotent (replace on re-run). A failure on one table is recorded and the run
+   continues. Every move (including dry-run skips) writes one row to the ledger:
+   source table, dest table, row count, status, detail, run timestamp, dry-run
+   flag.
+
+`MODE=all` runs DISCOVER then MOVE in a single run.
+
+## Questions to answer
+
+- What is in scope: one Snowflake database (set `SNOWFLAKE_DATABASE`), or every visible database (leave it unset)? And optionally one schema?
+- Which account, user, warehouse, and role should the Flight connect with, and are the credentials stored as a MotherDuck Flights secret? Discovery needs a warehouse.
+- Where should the inventory, ledger, and moved tables live in MotherDuck (`TARGET_DB`, `TARGET_SCHEMA`, `CONTROL_SCHEMA`)?
+- After discovery, which tables should actually move? Edit the `selected` column, or accept the default rule (base tables only).
+- Are any in-scope tables large enough to need staging or a `MAX_ROWS_PER_TABLE` sample first?
+- Which service account token can write to `TARGET_DB`?
+
+## Caveats
+
+- **No credential-free smoke test.** Unlike the `sample_data`-backed templates
+  here, this Flight needs a real, reachable Snowflake account even to discover.
+  There is no offline dry run of the Snowflake side; the closest thing is
+  `DRY_RUN=true`, which still discovers but does not copy data.
+- **Discovery needs an active warehouse.** `SHOW TERSE DATABASES` runs without
+  one, but `INFORMATION_SCHEMA.TABLES` does not: with no warehouse every
+  per-database scan fails with "No active warehouse selected" and is skipped, so
+  the inventory comes back empty. Set `SNOWFLAKE_WAREHOUSE` (or give the connecting
+  user a default warehouse). Verified live: an account-wide scan of 4 databases
+  found 315 tables once a warehouse was set, and 0 before.
+- **Account-wide scan includes shared and system databases.** Leaving
+  `SNOWFLAKE_DATABASE` unset scans everything `SHOW TERSE DATABASES` returns,
+  which can include `SNOWFLAKE` (account views) and `SNOWFLAKE_SAMPLE_DATA`. Only
+  base tables are pre-`selected`, so views are inventoried but not moved by
+  default. Curate `selected` before moving, and note that the move destination is
+  keyed on table name alone, so same-named tables across databases or schemas
+  would collide in `TARGET_DB`.
+- **Re-discovery resets manual `selected` edits.** DISCOVER does a
+  `CREATE OR REPLACE` of the inventory, so any hand edits to `selected` are lost
+  on the next discover. To keep a curated selection, either stop re-discovering,
+  apply a deterministic `UPDATE ... SET selected = (...)` rule after each
+  discover, or maintain your selection in a separate table you join against.
+- **Snowflake compute and egress cost money.** Every discover query and every
+  `SELECT *` runs on a Snowflake warehouse and transfers data out. Use a small
+  warehouse, scope tightly with `SNOWFLAKE_SCHEMA`, and consider
+  `MAX_ROWS_PER_TABLE` for a sampled first pass.
+- **`ACCOUNT_USAGE` lags.** The account-wide alternative,
+  `SNOWFLAKE.ACCOUNT_USAGE.TABLES`, spans all databases but is delayed by up to
+  ~90 minutes and lists dropped tables until purged. This template uses the live,
+  exact `INFORMATION_SCHEMA.TABLES`, which is scoped to one database.
+- **Very large tables use memory.** MOVE fetches each table's full result into
+  one in-memory Arrow table. A Flight has a ~16GB RAM ceiling and ~150GB of local
+  scratch on `/tmp`. For a table that will not fit in memory, stage it to local
+  Parquet on `/tmp` first (`COPY ... TO '/tmp/...parquet'` from Snowflake or a
+  paged Arrow write), then load from Parquet, instead of one big `fetch_arrow_all`.
+- **`DRY_RUN` defaults to true.** MOVE writes real tables, so the first deploy
+  logs the move plan and writes ledger rows without copying. Set `DRY_RUN=false`
+  once you have reviewed the inventory.
+
 ## What you'll adjust
 
 Every knob is read from Flight config/env, so you adapt this template by setting
@@ -57,15 +133,6 @@ plain config.
 | `DRY_RUN` | config / env | `true` | When true, MOVE logs the plan and writes ledger rows without copying data. Set `false` to copy for real. |
 | `SNOWFLAKE_PASSWORD` | Flight secret / env var | (required) | The Snowflake credential. Add it through a MotherDuck Flights secret (in the UI, see below), never in code or config. As a Flight the secret arrives as `<secret_name>_SNOWFLAKE_PASSWORD`; `flight.py` resolves either name. |
 | `MOTHERDUCK_TOKEN` | Flight-injected | (Flight-injected) | Auth for MotherDuck. Select a token on the Flight; never hard-code it. |
-
-## Questions to answer
-
-- What is in scope: one Snowflake database (set `SNOWFLAKE_DATABASE`), or every visible database (leave it unset)? And optionally one schema?
-- Which account, user, warehouse, and role should the Flight connect with, and are the credentials stored as a MotherDuck Flights secret? Discovery needs a warehouse.
-- Where should the inventory, ledger, and moved tables live in MotherDuck (`TARGET_DB`, `TARGET_SCHEMA`, `CONTROL_SCHEMA`)?
-- After discovery, which tables should actually move? Edit the `selected` column, or accept the default rule (base tables only).
-- Are any in-scope tables large enough to need staging or a `MAX_ROWS_PER_TABLE` sample first?
-- Which service account token can write to `TARGET_DB`?
 
 ## Run it
 
@@ -153,73 +220,6 @@ Create the Flight with `MODE=discover`, trigger one manual run with
 listed by `MD_FLIGHTS()`), and confirm the inventory lands in MotherDuck. Curate `selected`, then run
 `MODE=move` with `DRY_RUN=false` (a config change, not a new Flight version) to
 copy. Schedule it only if you want a recurring refresh.
-
-## How it works
-
-`flight.py` connects to MotherDuck (`md:`), creates `TARGET_DB`, the control
-schema, and the target schema if missing, then runs one or both phases:
-
-1. **DISCOVER.** Determine the databases in scope: just `SNOWFLAKE_DATABASE` when
-   set, otherwise every database the connection can see (via `SHOW TERSE
-   DATABASES`). For each, query its `INFORMATION_SCHEMA.TABLES` (optionally
-   filtered to `SNOWFLAKE_SCHEMA`), listing `table_catalog, table_schema,
-   table_name, row_count, bytes, table_type`, and skip any database the role
-   cannot read. Write the combined result to the inventory control table with an
-   added `selected BOOLEAN` (defaulted to `table_type = 'BASE TABLE'`) and a
-   `discovered_at` timestamp. The write is a `CREATE OR REPLACE`, so re-discovery
-   refreshes the inventory.
-2. **MOVE.** Read the rows where `selected` is true. For each, run
-   `SELECT * FROM <db>.<schema>.<table>` in Snowflake, fetch the result as one
-   Arrow table with `cursor.fetch_arrow_all()`, register that Arrow object with
-   the DuckDB connection, and `CREATE OR REPLACE TABLE
-   <TARGET_DB>.<TARGET_SCHEMA>.<table> AS SELECT * FROM <arrow>`. Each table is
-   idempotent (replace on re-run). A failure on one table is recorded and the run
-   continues. Every move (including dry-run skips) writes one row to the ledger:
-   source table, dest table, row count, status, detail, run timestamp, dry-run
-   flag.
-
-`MODE=all` runs DISCOVER then MOVE in a single run.
-
-## Caveats
-
-- **No credential-free smoke test.** Unlike the `sample_data`-backed templates
-  here, this Flight needs a real, reachable Snowflake account even to discover.
-  There is no offline dry run of the Snowflake side; the closest thing is
-  `DRY_RUN=true`, which still discovers but does not copy data.
-- **Discovery needs an active warehouse.** `SHOW TERSE DATABASES` runs without
-  one, but `INFORMATION_SCHEMA.TABLES` does not: with no warehouse every
-  per-database scan fails with "No active warehouse selected" and is skipped, so
-  the inventory comes back empty. Set `SNOWFLAKE_WAREHOUSE` (or give the connecting
-  user a default warehouse). Verified live: an account-wide scan of 4 databases
-  found 315 tables once a warehouse was set, and 0 before.
-- **Account-wide scan includes shared and system databases.** Leaving
-  `SNOWFLAKE_DATABASE` unset scans everything `SHOW TERSE DATABASES` returns,
-  which can include `SNOWFLAKE` (account views) and `SNOWFLAKE_SAMPLE_DATA`. Only
-  base tables are pre-`selected`, so views are inventoried but not moved by
-  default. Curate `selected` before moving, and note that the move destination is
-  keyed on table name alone, so same-named tables across databases or schemas
-  would collide in `TARGET_DB`.
-- **Re-discovery resets manual `selected` edits.** DISCOVER does a
-  `CREATE OR REPLACE` of the inventory, so any hand edits to `selected` are lost
-  on the next discover. To keep a curated selection, either stop re-discovering,
-  apply a deterministic `UPDATE ... SET selected = (...)` rule after each
-  discover, or maintain your selection in a separate table you join against.
-- **Snowflake compute and egress cost money.** Every discover query and every
-  `SELECT *` runs on a Snowflake warehouse and transfers data out. Use a small
-  warehouse, scope tightly with `SNOWFLAKE_SCHEMA`, and consider
-  `MAX_ROWS_PER_TABLE` for a sampled first pass.
-- **`ACCOUNT_USAGE` lags.** The account-wide alternative,
-  `SNOWFLAKE.ACCOUNT_USAGE.TABLES`, spans all databases but is delayed by up to
-  ~90 minutes and lists dropped tables until purged. This template uses the live,
-  exact `INFORMATION_SCHEMA.TABLES`, which is scoped to one database.
-- **Very large tables use memory.** MOVE fetches each table's full result into
-  one in-memory Arrow table. A Flight has a ~16GB RAM ceiling and ~150GB of local
-  scratch on `/tmp`. For a table that will not fit in memory, stage it to local
-  Parquet on `/tmp` first (`COPY ... TO '/tmp/...parquet'` from Snowflake or a
-  paged Arrow write), then load from Parquet, instead of one big `fetch_arrow_all`.
-- **`DRY_RUN` defaults to true.** MOVE writes real tables, so the first deploy
-  logs the move plan and writes ledger rows without copying. Set `DRY_RUN=false`
-  once you have reviewed the inventory.
 
 ## Security
 

--- a/flight-plans/flight-sql-transformation/README.md
+++ b/flight-plans/flight-sql-transformation/README.md
@@ -25,6 +25,37 @@ The example statements live in `sql_statements()` — the example is one chain c
 table, a view, a scalar macro, a diamond, and a dependency on a table this
 Flight does not create. Replace them with your own; the engine stays untouched.
 
+## How it works
+
+1. Parse each statement with sqlglot to get its produced object and its table
+   and macro references.
+2. Build the DAG: a reference matching another statement's output becomes an
+   edge. Table/view references resolve against table/view producers, macro calls
+   against macros. Duplicate targets, ambiguous references, and cycles are
+   rejected before anything runs.
+3. Execute on a `ThreadPoolExecutor`: launch every node whose upstreams have all
+   succeeded, retry each with exponential backoff, and on a permanent failure
+   skip its downstream while independent branches finish. The report logs each
+   statement's status, attempts, and duration.
+
+## Questions to answer
+
+- What `CREATE` statements make up your pipeline?
+- What is the destination database?
+- How many statements can safely run at once?
+- On what schedule (cron, UTC) should it run?
+
+## Caveats
+
+- **External references are not dependencies.** A reference no statement produces
+  (`read_csv(...)`, `sample_data.*`, a pre-existing table) creates no edge and is
+  treated as an existing input.
+- **Ambiguous references fail fast.** A reference matching two produced objects
+  (e.g. bare `t` when both `a.t` and `b.t` exist) raises rather than guess.
+  Qualify the name to disambiguate.
+- **Statements must be `CREATE ... AS <query>`.** A non-`CREATE` statement, or a
+  `CREATE TABLE` with only a column list and no `AS`, is rejected.
+
 ## What you'll adjust
 
 | Knob | Where | Default | Purpose |
@@ -34,13 +65,6 @@ Flight does not create. Replace them with your own; the engine stays untouched.
 | `MAX_WORKERS` | Flight config / env | `4` | Thread-pool size — independent statements run at once. |
 | `MAX_ATTEMPTS` | Flight config / env | `4` | Retries per statement before skipping downstream statements. |
 | `RETRY_BASE_DELAY` | Flight config / env | `1.0` | First delay before retry (doubles each retry, capped at 30s). |
-
-## Questions to answer
-
-- What `CREATE` statements make up your pipeline?
-- What is the destination database?
-- How many statements can safely run at once?
-- On what schedule (cron, UTC) should it run?
 
 ## Run it
 
@@ -57,40 +81,17 @@ exit means at least one statement failed.
 
 ### Deploy as a Flight
 
-Deploy with the MotherDuck MCP server. Call `get_flight_guide` first for the
-exact arguments, then `create_flight` with:
+Deploy through the Flight SQL surface (`MD_CREATE_FLIGHT`, then
+`MD_RUN_FLIGHT`) with:
 
 - `source_code`: [`flight.py`](flight.py), with `sql_statements()` edited to your statements
 - `requirements_txt`: [`requirements.txt`](requirements.txt)
-- `access_token_name`: a token that can write the destination (list with `md_access_tokens()`); injected as `MOTHERDUCK_TOKEN`
 - `config`: `TARGET_DATABASE`, `MAX_WORKERS` as needed
 
-Create it without a schedule, trigger one run with `run_flight` to confirm it
-loads, then add a `schedule_cron` using cron syntax based on user input.
-
-## How it works
-
-1. Parse each statement with sqlglot to get its produced object and its table
-   and macro references.
-2. Build the DAG: a reference matching another statement's output becomes an
-   edge. Table/view references resolve against table/view producers, macro calls
-   against macros. Duplicate targets, ambiguous references, and cycles are
-   rejected before anything runs.
-3. Execute on a `ThreadPoolExecutor`: launch every node whose upstreams have all
-   succeeded, retry each with exponential backoff, and on a permanent failure
-   skip its downstream while independent branches finish. The report logs each
-   statement's status, attempts, and duration.
-
-## Caveats
-
-- **External references are not dependencies.** A reference no statement produces
-  (`read_csv(...)`, `sample_data.*`, a pre-existing table) creates no edge and is
-  treated as an existing input.
-- **Ambiguous references fail fast.** A reference matching two produced objects
-  (e.g. bare `t` when both `a.t` and `b.t` exist) raises rather than guess.
-  Qualify the name to disambiguate.
-- **Statements must be `CREATE ... AS <query>`.** A non-`CREATE` statement, or a
-  `CREATE TABLE` with only a column list and no `AS`, is rejected.
+The Flight runtime injects `MOTHERDUCK_TOKEN`; make sure it can write the
+destination database. Create the Flight without a schedule, trigger one run with
+`MD_RUN_FLIGHT` to confirm it loads, then add a `schedule_cron` using cron
+syntax based on user input.
 
 ## Learn more
 

--- a/motherduck-grafana/README.md
+++ b/motherduck-grafana/README.md
@@ -39,6 +39,26 @@ A local Grafana setup that connects to MotherDuck through the `motherduck-duckdb
 - `provisioning/dashboards/dashboards.yaml`: registers the file provider that loads every dashboard from `/etc/grafana/provisioning/dashboards/json`.
 - `provisioning/dashboards/json/`: holds the dashboard definitions. `nyc_services.json` groups `sample_data.nyc.service_requests` by `created_date`; `nyc_rideshare.json` groups `sample_data.nyc.rideshare` by `request_datetime`.
 
+## Questions to answer
+
+- Which MotherDuck database(s) and schema(s) should be attached (the `initSql` `ATTACH` target)?
+- Which tables or queries power the dashboards, and what is the time column for time-series panels?
+- Is a MotherDuck access token available, and should it be a read-scaling token (recommended for read-only dashboard traffic)?
+- Should this stay a local Docker setup, or be adapted for a hosted Grafana deployment?
+- Are there existing dashboard JSON exports to drop into `provisioning/dashboards/json/`?
+
+## Caveats
+
+- **Token in the environment, not the config.** The token is injected through `$__env{motherduck_token}` and the Docker `-e` flag at runtime. Do not hardcode it into `sample_data.yaml`, which is committed to the repo.
+- **Token must be exported before `setup.sh`.** If `motherduck_token` is unset the script exits before starting Grafana. If you start Grafana some other way without the variable, the datasource provisions but every query fails to authenticate.
+- **Windows is not supported by the script.** It exits on `CYGWIN`/`MINGW`/`MSYS`. On Windows, download and unzip the plugin into the Grafana plugin folder manually and run the container yourself.
+- **Port 3000 must be free.** The script stops a prior Grafana container on that port, but if anything else is listening on 3000 it aborts. Change the `-p` mapping if 3000 is taken.
+- **Unsigned plugin.** The datasource is loaded via `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS`. Grafana will refuse to load it without that allow-list entry.
+- **Time-series panels need a time column.** The panel format defaults to a table view; switch it to **time series** and make sure the query returns a timestamp/date column (`created_date`, `request_datetime`), or the panel renders nothing useful.
+- **Builder mode does not write DuckDB SQL for you.** Switch the query editor to **code** mode to run DuckDB syntax; the visual builder will not produce the MotherDuck-specific queries.
+- **`plugins/` is downloaded, not committed.** A fresh clone has no plugin until `setup.sh` runs and reaches GitHub; an offline machine cannot provision the datasource.
+- **`sample_data` is a public MotherDuck share.** The example dashboards read from it. To query your own data, change the `initSql` `ATTACH` target and the panel `rawSql` to your database and tables.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -52,14 +72,6 @@ A local Grafana setup that connects to MotherDuck through the `motherduck-duckdb
 | `provisioning/dashboards/dashboards.yaml` `path` | Where Grafana looks for dashboard JSON inside the container | `/etc/grafana/provisioning/dashboards/json` |
 | Grafana port mapping in `setup.sh` | Host port Grafana is published on | `-p 3000:3000` |
 | Grafana image tag in `setup.sh` | Grafana version that runs in the container | `grafana/grafana:latest-ubuntu` |
-
-## Questions to answer
-
-- Which MotherDuck database(s) and schema(s) should be attached (the `initSql` `ATTACH` target)?
-- Which tables or queries power the dashboards, and what is the time column for time-series panels?
-- Is a MotherDuck access token available, and should it be a read-scaling token (recommended for read-only dashboard traffic)?
-- Should this stay a local Docker setup, or be adapted for a hosted Grafana deployment?
-- Are there existing dashboard JSON exports to drop into `provisioning/dashboards/json/`?
 
 ## Run it
 
@@ -99,18 +111,6 @@ To add your own dashboard, export it from the Grafana UI (the **Export** button,
   - [`provisioning/dashboards/json/`](provisioning/dashboards/json/) - the example dashboard definitions (2 files): `nyc_services.json` (NYC Services, service requests by `created_date`) and `nyc_rideshare.json` (NYC_rideshare, rideshare totals).
 - [`image.png`](image.png) - screenshot showing where to set the time-series format and the code-mode query editor when building a panel.
 - `.gitignore` - excludes the downloaded `plugins/` directory and `.DS_Store`, so the plugin is fetched fresh by `setup.sh` and never committed.
-
-## Caveats
-
-- **Token in the environment, not the config.** The token is injected through `$__env{motherduck_token}` and the Docker `-e` flag at runtime. Do not hardcode it into `sample_data.yaml`, which is committed to the repo.
-- **Token must be exported before `setup.sh`.** If `motherduck_token` is unset the script exits before starting Grafana. If you start Grafana some other way without the variable, the datasource provisions but every query fails to authenticate.
-- **Windows is not supported by the script.** It exits on `CYGWIN`/`MINGW`/`MSYS`. On Windows, download and unzip the plugin into the Grafana plugin folder manually and run the container yourself.
-- **Port 3000 must be free.** The script stops a prior Grafana container on that port, but if anything else is listening on 3000 it aborts. Change the `-p` mapping if 3000 is taken.
-- **Unsigned plugin.** The datasource is loaded via `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS`. Grafana will refuse to load it without that allow-list entry.
-- **Time-series panels need a time column.** The panel format defaults to a table view; switch it to **time series** and make sure the query returns a timestamp/date column (`created_date`, `request_datetime`), or the panel renders nothing useful.
-- **Builder mode does not write DuckDB SQL for you.** Switch the query editor to **code** mode to run DuckDB syntax; the visual builder will not produce the MotherDuck-specific queries.
-- **`plugins/` is downloaded, not committed.** A fresh clone has no plugin until `setup.sh` runs and reaches GitHub; an offline machine cannot provision the datasource.
-- **`sample_data` is a public MotherDuck share.** The example dashboards read from it. To query your own data, change the `initSql` `ATTACH` target and the panel `rawSql` to your database and tables.
 
 ## Learn more
 

--- a/motherduck-ui/README.md
+++ b/motherduck-ui/README.md
@@ -76,6 +76,23 @@ FROM winelist
 WHERE vintage > 1000;
 ```
 
+## Questions to answer
+
+- What CSV (or other source) are you loading, and where does it live (local upload, S3, HTTPS)?
+- Which database and schema should the resulting table live in?
+- Which columns need cleaning, and what are their real formats (delimiters, currency symbols, units)?
+- Do you want to keep the cleaned result as a new table (`CREATE TABLE ... AS`) or just explore?
+- What analysis question are you trying to answer, and which columns drive the ranking or aggregation?
+
+## Caveats
+
+- **The exercise depends on a table the script does not build.** Running the final `with cte_cheap_but_good ... ` block before creating `winelist_clean` fails with a "table does not exist" (Catalog) error. Persist the cleaned `SELECT` as `winelist_clean` first.
+- **Column names are case- and whitespace-sensitive.** The raw CSV header has `Wine name`, `Quantity`, and a price column written as ` Offer Price ` (note the surrounding spaces). `read_csv_auto` normalizes some of this, but the script refers to identifiers like `"Wine Name"` and `"Offer price"`. If a `SELECT` errors on an unknown column, run `SUMMARIZE winelist` (or `DESCRIBE winelist`) and copy the exact column name, including spaces, into double quotes. Double quotes are for identifiers; single quotes are for string literals like `'$'`.
+- **The unit-size parser assumes a fixed format.** `substr(..., length(...) - instr(..., 'x') - 2)` hard-codes a 2-character trailing unit (`cl`). A value like `1x150cl` parses, but a different unit (`ml`, `L`) or a missing `x` delimiter will silently produce a wrong number or fail the `integer` cast. Validate `qty` and `volume_cl` against the source before trusting the derived prices.
+- **`price_per_75cl` divides by `qty * volume_cl`.** If either parses to `0` or `NULL`, you get a division-by-zero or `NULL`. Confirm the parse step is clean before computing the ratio.
+- **`WHERE vintage > 1000` is a blunt filter,** kept only to drop obviously-junk vintages. It is not a real validity check; adjust it for your data rather than assuming it cleans everything.
+- **The example is built for the UI's run-one-query-at-a-time flow.** Running the whole `script.sql` in a CLI in one go defeats the inspect-each-step purpose and surfaces the `winelist_clean` error immediately.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -87,14 +104,6 @@ WHERE vintage > 1000;
 | `"Offer price"` cleanup | `replace(...)` strips `$` and `,` before casting to `decimal(10,2)` | Change the symbols stripped, the precision/scale, and the source column name |
 | `WHERE vintage > 1000` | Filter that removes obvious bad rows | Replace with your own validity filter, or drop it |
 | Exercise thresholds | The analysis query filters `Vintage >= 1990` and ranks on `coalesce(coalesce("WA score","Vinous score"),-1)` and `price_per_bottle` | Change the year cutoff, scoring columns, and ranking metric for your question |
-
-## Questions to answer
-
-- What CSV (or other source) are you loading, and where does it live (local upload, S3, HTTPS)?
-- Which database and schema should the resulting table live in?
-- Which columns need cleaning, and what are their real formats (delimiters, currency symbols, units)?
-- Do you want to keep the cleaned result as a new table (`CREATE TABLE ... AS`) or just explore?
-- What analysis question are you trying to answer, and which columns drive the ranking or aggregation?
 
 ## Run it
 
@@ -110,15 +119,6 @@ You can also run the script from the DuckDB or MotherDuck CLI, but it is written
 
 - [`script.sql`](script.sql) - the guided SQL walkthrough: loads the CSV, runs `SUMMARIZE`, builds up the cleaning `SELECT` step by step (drop bad rows, parse `Unit size`, normalize the price), and ends with the exercise query.
 - [`winelist_sample.csv`](winelist_sample.csv) - the intentionally messy source data: ~2,450 rows of wine merchant offers with country, region, producer, wine name, vintage, unit size (e.g. `6x75cl`), WA and Vinous scores, quantity, and a dollar-formatted offer price.
-
-## Caveats
-
-- **The exercise depends on a table the script does not build.** Running the final `with cte_cheap_but_good ... ` block before creating `winelist_clean` fails with a "table does not exist" (Catalog) error. Persist the cleaned `SELECT` as `winelist_clean` first.
-- **Column names are case- and whitespace-sensitive.** The raw CSV header has `Wine name`, `Quantity`, and a price column written as ` Offer Price ` (note the surrounding spaces). `read_csv_auto` normalizes some of this, but the script refers to identifiers like `"Wine Name"` and `"Offer price"`. If a `SELECT` errors on an unknown column, run `SUMMARIZE winelist` (or `DESCRIBE winelist`) and copy the exact column name, including spaces, into double quotes. Double quotes are for identifiers; single quotes are for string literals like `'$'`.
-- **The unit-size parser assumes a fixed format.** `substr(..., length(...) - instr(..., 'x') - 2)` hard-codes a 2-character trailing unit (`cl`). A value like `1x150cl` parses, but a different unit (`ml`, `L`) or a missing `x` delimiter will silently produce a wrong number or fail the `integer` cast. Validate `qty` and `volume_cl` against the source before trusting the derived prices.
-- **`price_per_75cl` divides by `qty * volume_cl`.** If either parses to `0` or `NULL`, you get a division-by-zero or `NULL`. Confirm the parse step is clean before computing the ratio.
-- **`WHERE vintage > 1000` is a blunt filter,** kept only to drop obviously-junk vintages. It is not a real validity check; adjust it for your data rather than assuming it cleans everything.
-- **The example is built for the UI's run-one-query-at-a-time flow.** Running the whole `script.sql` in a CLI in one go defeats the inspect-each-step purpose and surfaces the `winelist_clean` error immediately.
 
 ## Learn more
 

--- a/nba-box-scores/README.md
+++ b/nba-box-scores/README.md
@@ -33,6 +33,19 @@ Two decoupled slices:
 The Flight keeps `nba_box_scores_v3` current; the Dive queries it live. Each
 slice's README covers its own deeper development and deploy details.
 
+## How it works
+
+- [`flight/README.md`](./flight/README.md) — pipeline layout, local development, and Flight registration.
+- [`dive/README.md`](./dive/README.md) — the three-tab Dive, the esbuild bundle, deploy SQL, and data-modeling notes (stable `entity_id` aggregation, the `game_quality = -1` sub-15-minute sentinel, and Dive-renderer styling caveats).
+
+## Questions to answer
+
+- Which MotherDuck database holds the box-score tables? (Default `nba_box_scores_v3`.)
+- Which seasons do you need — the current season on a nightly schedule, a historical range to backfill, or both?
+- Which MotherDuck token name does the Flight inject, and does it have read+write on that database? (Default `dives-loader-nba`.)
+- Production tables, or an isolated `_new` suffix to validate a run before promoting?
+- What Dive title do you deploy under (the script resolves it by title), and are you deploying with a DuckDB **1.5.2** client (MotherDuck rejects 1.5.3)?
+
 ## What you'll adjust
 
 | Knob | Where | Purpose |
@@ -47,14 +60,6 @@ slice's README covers its own deeper development and deploy details.
 | `md_token_name` | `flight/flights/*/flight.toml` | MotherDuck token the Flight runtime injects as `MOTHERDUCK_TOKEN`. Default `dives-loader-nba`. |
 | `schedule_cron` | `flight/flights/nba_nightly/flight.toml` | Nightly schedule. Default `0 16 * * *` (16:00 UTC). |
 | `DIVE_TITLE` / `NBA_DIVE_DATABASE` | env (`dive/scripts/deploy-dive.sh`) | Dive title to create/update (default `NBA Box Scores`) and the source database bound to its `nba_box_scores_v3` alias. |
-
-## Questions to answer
-
-- Which MotherDuck database holds the box-score tables? (Default `nba_box_scores_v3`.)
-- Which seasons do you need — the current season on a nightly schedule, a historical range to backfill, or both?
-- Which MotherDuck token name does the Flight inject, and does it have read+write on that database? (Default `dives-loader-nba`.)
-- Production tables, or an isolated `_new` suffix to validate a run before promoting?
-- What Dive title do you deploy under (the script resolves it by title), and are you deploying with a DuckDB **1.5.2** client (MotherDuck rejects 1.5.3)?
 
 ## Run it
 
@@ -108,8 +113,6 @@ creating it the first time and updating its content after — no Dive id is pinn
 in the repo. See [`dive/README.md`](./dive/README.md) for the title/database
 overrides and the underlying SQL.
 
-## How it works / Learn more
+## Learn more
 
-- [`flight/README.md`](./flight/README.md) — pipeline layout, local development, and Flight registration.
-- [`dive/README.md`](./dive/README.md) — the three-tab Dive, the esbuild bundle, deploy SQL, and data-modeling notes (stable `entity_id` aggregation, the `game_quality = -1` sub-15-minute sentinel, and Dive-renderer styling caveats).
 - For Flight and Dive deployment mechanics, see the MotherDuck MCP guides (`get_flight_guide`, `get_dive_guide`) and `ask_docs_question`.

--- a/nodejs-motherduck/README.md
+++ b/nodejs-motherduck/README.md
@@ -80,6 +80,26 @@ async validate(resource) {
 }
 ```
 
+## Questions to answer
+
+- Which MotherDuck database and schema should the scripts target? Default is `my_db`; sample queries read the `sample_data.nyc` share.
+- Is a MotherDuck access token available, and where should it live? These scripts read it from `MOTHERDUCK_TOKEN` in `.env`.
+- Is this a one-shot script or a long-running service: does it need the connection pool, and at what concurrency (min/max, recycle timers)?
+- What queries or tables should replace the `example_users` and `nyc.taxi` samples?
+- Does the runtime ship the DuckDB binary (native driver), or does it need the Postgres endpoint instead (see `cloudflare-workers` for that pattern)?
+
+## Caveats
+
+- The native driver loads the DuckDB binary in-process. Runtimes that cannot ship a native addon (Cloudflare Workers, some serverless platforms, browsers) will fail to load `@duckdb/node-api`. Use the Postgres endpoint there instead (`cloudflare-workers` example).
+- Do not call `DuckDBInstance.create()` per request or per pooled connection: that re-loads the MotherDuck extension and re-fetches catalog metadata every time. Always go through `fromCache()` so connections share one instance.
+- Keep the token out of source control. The token is read from `MOTHERDUCK_TOKEN` in `.env`, and `.gitignore` already excludes `.env`. Do not hardcode it into `basic.js`, `connection-pool.js`, or commit a populated `.env`. If `MOTHERDUCK_TOKEN` is unset, both scripts exit early with a clear error.
+- ESM only: `package.json` sets `"type": "module"`, so use `import`, not `require`. Node.js below 22 may not support the syntax used here.
+- `validate()` only recycles a connection on borrow (`testOnBorrow: true`). A connection that sits idle past `idleTimeoutMillis` is evicted by the eviction sweep, but staleness is checked when the connection is handed out, not continuously. Tune `recycleTimeoutMillis`, `evictionRunIntervalMillis`, and the idle timeouts together.
+- `SET THREADS='1'` trades per-query speed for fair CPU sharing across the pool. If you raise `max` without watching threads, pooled connections can oversubscribe CPU; if a single query is slow and concurrency is low, raise the thread count.
+- The pool example reads only from `sample_data.nyc.taxi`; the writes in `basic.js` create and drop `example_users` in your target database. Point these at a database you are allowed to write to, and note that `basic.js` drops `example_users` on exit (in its `finally` block).
+- `getRowObjects()` returns DuckDB-typed values; large integers come back as `BigInt`, not `Number`. Handle that when serializing results (for example `JSON.stringify` on a `BigInt` throws).
+- Always close connections (`connection.closeSync()`) and drain the pool (`pool.drain()` then `pool.clear()`) on shutdown, or the process can hang on open handles.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -92,14 +112,6 @@ async validate(resource) {
 | Eviction / recycle timers in `src/connection-pool.js` | Idle cleanup and connection recycling | `softIdleTimeoutMillis: 60000`, `idleTimeoutMillis: 120000`, `recycleTimeoutMillis: 300000` |
 | `SET THREADS='1'` in the pool factory | Threads per pooled connection so they don't compete for CPU | Raise or drop depending on concurrency vs per-query speed |
 | `queries` array in `src/connection-pool.js` | The concurrent queries run through the pool | Replace the `sample_data.nyc.taxi` aggregates with your own SQL |
-
-## Questions to answer
-
-- Which MotherDuck database and schema should the scripts target? Default is `my_db`; sample queries read the `sample_data.nyc` share.
-- Is a MotherDuck access token available, and where should it live? These scripts read it from `MOTHERDUCK_TOKEN` in `.env`.
-- Is this a one-shot script or a long-running service: does it need the connection pool, and at what concurrency (min/max, recycle timers)?
-- What queries or tables should replace the `example_users` and `nyc.taxi` samples?
-- Does the runtime ship the DuckDB binary (native driver), or does it need the Postgres endpoint instead (see `cloudflare-workers` for that pattern)?
 
 ## Run it
 
@@ -129,18 +141,6 @@ npm run pool
 - [`.env.template`](.env.template) - environment template: copy to `.env` and set `MOTHERDUCK_TOKEN` (and optionally `MOTHERDUCK_DATABASE`).
 - [`.nvmrc`](.nvmrc) - pins Node.js 22 for tools like `nvm`.
 - [`.gitignore`](.gitignore) - excludes `node_modules/`, `.env`, local DuckDB files, and other noise from version control.
-
-## Caveats
-
-- The native driver loads the DuckDB binary in-process. Runtimes that cannot ship a native addon (Cloudflare Workers, some serverless platforms, browsers) will fail to load `@duckdb/node-api`. Use the Postgres endpoint there instead (`cloudflare-workers` example).
-- Do not call `DuckDBInstance.create()` per request or per pooled connection: that re-loads the MotherDuck extension and re-fetches catalog metadata every time. Always go through `fromCache()` so connections share one instance.
-- Keep the token out of source control. The token is read from `MOTHERDUCK_TOKEN` in `.env`, and `.gitignore` already excludes `.env`. Do not hardcode it into `basic.js`, `connection-pool.js`, or commit a populated `.env`. If `MOTHERDUCK_TOKEN` is unset, both scripts exit early with a clear error.
-- ESM only: `package.json` sets `"type": "module"`, so use `import`, not `require`. Node.js below 22 may not support the syntax used here.
-- `validate()` only recycles a connection on borrow (`testOnBorrow: true`). A connection that sits idle past `idleTimeoutMillis` is evicted by the eviction sweep, but staleness is checked when the connection is handed out, not continuously. Tune `recycleTimeoutMillis`, `evictionRunIntervalMillis`, and the idle timeouts together.
-- `SET THREADS='1'` trades per-query speed for fair CPU sharing across the pool. If you raise `max` without watching threads, pooled connections can oversubscribe CPU; if a single query is slow and concurrency is low, raise the thread count.
-- The pool example reads only from `sample_data.nyc.taxi`; the writes in `basic.js` create and drop `example_users` in your target database. Point these at a database you are allowed to write to, and note that `basic.js` drops `example_users` on exit (in its `finally` block).
-- `getRowObjects()` returns DuckDB-typed values; large integers come back as `BigInt`, not `Number`. Handle that when serializing results (for example `JSON.stringify` on a `BigInt` throws).
-- Always close connections (`connection.closeSync()`) and drain the pool (`pool.drain()` then `pool.clear()`) on shutdown, or the process can hang on open handles.
 
 ## Learn more
 

--- a/postgres-demo/README.md
+++ b/postgres-demo/README.md
@@ -17,6 +17,31 @@ This example runs a local Postgres using the `pgduckdb/pgduckdb` Docker image, w
 
 Note this is the `pg_duckdb` / pg scanner path: DuckDB embedded inside Postgres, reaching MotherDuck via the `MOTHERDUCK_TOKEN`. It is not the MotherDuck Postgres wire endpoint (where a plain psql client connects directly to MotherDuck). If you only want a Postgres driver pointed at MotherDuck, you want the wire endpoint instead, not this image.
 
+## How it works
+
+- The `pgduckdb/pgduckdb` container embeds DuckDB inside Postgres and reaches MotherDuck through `MOTHERDUCK_TOKEN`.
+- The DuckDB CLI uses the `postgres` extension to attach the local Postgres container and scan its tables.
+- `CREATE TABLE AS SELECT` copies data across the boundary when you want a local replica rather than a live hybrid query.
+
+## Questions to answer
+
+- Which direction is needed: read Postgres from MotherDuck/DuckDB, read MotherDuck from Postgres, or both?
+- Which source table(s) in Postgres or MotherDuck should be moved, and to which target database and schema?
+- Is this a one-time copy (CTAS) or do you expect to query the two systems live in a hybrid query?
+- Which MotherDuck region and token should the container use, and where is that token stored?
+- Is the local Postgres password and host the default from this example, or have they been changed? The ATTACH string must match whatever you set.
+- Does the source table already exist in the system you are reading from? If not, create and load it first.
+
+## Caveats
+
+- **The source table must already exist.** `winelist` is assumed to be present; this example does not create or seed it. `SELECT * FROM pg.public.winelist` (or the psql equivalent) errors with a missing-table error until you create and load it yourself. Load a table on the side you intend to read first.
+- **Keep the ATTACH string in sync with the container env.** If you change `POSTGRES_PASSWORD`, remap the port (e.g. `-p 5433:5432`), or run on a different host, the `password=`, `host=`, and implied port in the ATTACH connection string must all match, or the attach fails silently from the user's point of view (it just cannot connect).
+- **Use `host=127.0.0.1`, not the container name.** The DuckDB CLI runs on your host, not inside the container, so it reaches Postgres through the published port on `127.0.0.1`. On some systems `localhost` resolves to IPv6 first and the connection hangs or refuses; prefer `127.0.0.1`.
+- **`pg_duckdb` is not the Postgres wire endpoint.** This image embeds DuckDB inside Postgres and reaches MotherDuck via a token. It is a different mechanism from MotherDuck's Postgres wire endpoint. Picking the wrong one is the most common confusion here. Use this image only when you actually want Postgres and MotherDuck reading each other's tables locally.
+- **Forgetting `duckdb.motherduck_enabled=true` fails quietly.** Without that flag the container starts fine and ordinary Postgres works, but MotherDuck tables will not be reachable from psql.
+- **Do not commit your real token or password.** `very_secur3_pw` and `your_token` are placeholders. Do not bake a real `MOTHERDUCK_TOKEN` into a committed script or image; pass it as runtime env. The example password is intentionally weak and is fine for a local throwaway container only.
+- **5432 is often already in use** (a local Postgres install, another container). If `docker run` reports the port is allocated, remap the host side and update the ATTACH string accordingly.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -28,15 +53,6 @@ Note this is the `pg_duckdb` / pg scanner path: DuckDB embedded inside Postgres,
 | ATTACH connection string (DuckDB CLI) | Where the DuckDB CLI finds the local Postgres | `dbname=postgres user=postgres password=... host=127.0.0.1` |
 | Source table (`pg.public.winelist`) | The Postgres table you scan from DuckDB | Replace `winelist` with your own table and schema; this table must already exist (see Caveats) |
 | Target database / schema | Where CTAS writes the replicated data | A MotherDuck database for PG to MD, or `public` in Postgres for MD to PG |
-
-## Questions to answer
-
-- Which direction is needed: read Postgres from MotherDuck/DuckDB, read MotherDuck from Postgres, or both?
-- Which source table(s) in Postgres or MotherDuck should be moved, and to which target database and schema?
-- Is this a one-time copy (CTAS) or do you expect to query the two systems live in a hybrid query?
-- Which MotherDuck region and token should the container use, and where is that token stored?
-- Is the local Postgres password and host the default from this example, or have they been changed? The ATTACH string must match whatever you set.
-- Does the source table already exist in the system you are reading from? If not, create and load it first.
 
 ## Run it
 
@@ -102,17 +118,7 @@ FROM public.winelist_local AS local
 JOIN <motherduck_table> AS md USING (id);
 ```
 
-## Caveats
-
-- **The source table must already exist.** `winelist` is assumed to be present; this example does not create or seed it. `SELECT * FROM pg.public.winelist` (or the psql equivalent) errors with a missing-table error until you create and load it yourself. Load a table on the side you intend to read first.
-- **Keep the ATTACH string in sync with the container env.** If you change `POSTGRES_PASSWORD`, remap the port (e.g. `-p 5433:5432`), or run on a different host, the `password=`, `host=`, and implied port in the ATTACH connection string must all match, or the attach fails silently from the user's point of view (it just cannot connect).
-- **Use `host=127.0.0.1`, not the container name.** The DuckDB CLI runs on your host, not inside the container, so it reaches Postgres through the published port on `127.0.0.1`. On some systems `localhost` resolves to IPv6 first and the connection hangs or refuses; prefer `127.0.0.1`.
-- **`pg_duckdb` is not the Postgres wire endpoint.** This image embeds DuckDB inside Postgres and reaches MotherDuck via a token. It is a different mechanism from MotherDuck's Postgres wire endpoint. Picking the wrong one is the most common confusion here. Use this image only when you actually want Postgres and MotherDuck reading each other's tables locally.
-- **Forgetting `duckdb.motherduck_enabled=true` fails quietly.** Without that flag the container starts fine and ordinary Postgres works, but MotherDuck tables will not be reachable from psql.
-- **Do not commit your real token or password.** `very_secur3_pw` and `your_token` are placeholders. Do not bake a real `MOTHERDUCK_TOKEN` into a committed script or image; pass it as runtime env. The example password is intentionally weak and is fine for a local throwaway container only.
-- **5432 is often already in use** (a local Postgres install, another container). If `docker run` reports the port is allocated, remap the host side and update the ATTACH string accordingly.
-
-## How it works / Learn more
+## Learn more
 
 - Loading data from Postgres into MotherDuck: [MotherDuck docs](https://motherduck.com/docs/key-tasks/loading-data-into-motherduck/loading-data-from-postgres/).
 - pg_duckdb (DuckDB embedded in Postgres) and the MotherDuck integration flag: the [pg_duckdb project](https://github.com/duckdb/pg_duckdb).

--- a/python-ingestion/README.md
+++ b/python-ingestion/README.md
@@ -91,6 +91,42 @@ where inference picks a wider or narrower type than you want.
 in-memory DuckDB database (no MotherDuck or network needed), covering a single
 insert, multiple inserts, and a 100-row table that spans many chunks.
 
+## Questions to answer
+
+- What is the source: an HTTP API, a local file, or an in-memory dataframe?
+- Which MotherDuck database and table should the data land in?
+- Small payload (pandas, one shot) or larger payload (typed PyArrow, chunked)?
+- Full refresh (create/replace) or append to an existing table?
+- How often should it run, and where will the `motherduck_token` come from?
+
+## Caveats
+
+- **`CREATE TABLE IF NOT EXISTS` does not refresh.** Both scripts only create the
+  table on the first run; later runs are silent no-ops and the data goes stale.
+  For a full refresh use `CREATE OR REPLACE TABLE`; to accumulate rows, create the
+  table once and `INSERT` on subsequent runs (the large script's pattern).
+- **Missing token fails at attach, not at startup.** If `.env` is absent, holds
+  the placeholder `mytoken`, or you run from a directory where `load_dotenv()`
+  cannot find `.env`, the script fails when it reaches `ATTACH 'md:'`. Confirm the
+  token is real and that you run from this folder.
+- **GitHub `stats/contributors` can return `202` with an empty body.** GitHub
+  computes contributor statistics asynchronously and returns `202 Accepted` with
+  no data on the first request for a repo. The script does not retry, so a cold
+  cache yields an empty load. Re-run after a moment, or handle `202` explicitly
+  for your own source.
+- **Unauthenticated GitHub API requests are rate limited** to roughly 60 per hour
+  per IP. For anything beyond a demo, send an authentication header, and do not
+  hardcode that token in the script or commit it.
+- **Keep secrets out of source and config.** The token belongs in `.env` (which
+  should be gitignored) or a real environment variable, never in `flight.py`-style
+  committed code or in the `.env.template`.
+- **The pandas path infers types.** For wide or sparse payloads, inference can
+  pick types you did not intend (for example everything as `VARCHAR`, or integers
+  promoted to floats by nulls). Prefer the typed PyArrow path when types matter.
+- **`chunk_size=10` is a demo value.** It is set small so the example logs several
+  chunks. Tiny chunks mean many round trips; raise it (around `100000`) for real
+  loads.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -102,14 +138,6 @@ insert, multiple inserts, and a 100-row table that spans many chunks.
 | Target table name | Where rows land: `github.github_commits` (small) / `github.github_commits_large` (large). | `<database>.<table>` |
 | Explicit schema (large script) | The PyArrow + DuckDB column types for typed ingestion. | `[("login", pa.string()), ("total_commits", pa.int64())]` |
 | `chunk_size` (large script) | Rows per INSERT batch. Set to 10 in the demo; use a larger value in production. | `100000` is a good default |
-
-## Questions to answer
-
-- What is the source: an HTTP API, a local file, or an in-memory dataframe?
-- Which MotherDuck database and table should the data land in?
-- Small payload (pandas, one shot) or larger payload (typed PyArrow, chunked)?
-- Full refresh (create/replace) or append to an existing table?
-- How often should it run, and where will the `motherduck_token` come from?
 
 ## Run it
 
@@ -143,34 +171,6 @@ uv run pytest tests
 - [`.env.template`](.env.template) - copy to `.env` and set `motherduck_token`; the scripts read it via `load_dotenv()`.
 - [`.python-version`](.python-version) - pins the interpreter to Python 3.12.
 - [`uv.lock`](uv.lock) - the pinned `uv` dependency lockfile.
-
-## Caveats
-
-- **`CREATE TABLE IF NOT EXISTS` does not refresh.** Both scripts only create the
-  table on the first run; later runs are silent no-ops and the data goes stale.
-  For a full refresh use `CREATE OR REPLACE TABLE`; to accumulate rows, create the
-  table once and `INSERT` on subsequent runs (the large script's pattern).
-- **Missing token fails at attach, not at startup.** If `.env` is absent, holds
-  the placeholder `mytoken`, or you run from a directory where `load_dotenv()`
-  cannot find `.env`, the script fails when it reaches `ATTACH 'md:'`. Confirm the
-  token is real and that you run from this folder.
-- **GitHub `stats/contributors` can return `202` with an empty body.** GitHub
-  computes contributor statistics asynchronously and returns `202 Accepted` with
-  no data on the first request for a repo. The script does not retry, so a cold
-  cache yields an empty load. Re-run after a moment, or handle `202` explicitly
-  for your own source.
-- **Unauthenticated GitHub API requests are rate limited** to roughly 60 per hour
-  per IP. For anything beyond a demo, send an authentication header, and do not
-  hardcode that token in the script or commit it.
-- **Keep secrets out of source and config.** The token belongs in `.env` (which
-  should be gitignored) or a real environment variable, never in `flight.py`-style
-  committed code or in the `.env.template`.
-- **The pandas path infers types.** For wide or sparse payloads, inference can
-  pick types you did not intend (for example everything as `VARCHAR`, or integers
-  promoted to floats by nulls). Prefer the typed PyArrow path when types matter.
-- **`chunk_size=10` is a demo value.** It is set small so the example logs several
-  chunks. Tiny chunks mean many round trips; raise it (around `100000`) for real
-  loads.
 
 ## Learn more
 

--- a/sqlmesh-demo/README.md
+++ b/sqlmesh-demo/README.md
@@ -81,6 +81,24 @@ The history loader coerces each OHLCV value defensively because `yfinance` may r
 
 - Audits run at execution time: `UNIQUE_COMBINATION_OF_COLUMNS`, `NOT_NULL`, and `UNIQUE_VALUES`. A failed audit blocks the model from being promoted, which is how data quality is enforced rather than just reported.
 
+## Questions to answer
+
+- Which tickers or source dataset should the pipeline load (replace `symbols.txt`, or swap dlt for a different source)?
+- What MotherDuck database and schema are the target? Set both the dlt `destination` database and `transform/config.yaml` `database`, and keep them in sync.
+- Full refresh or incremental, and what is the backfill start date for time-based models?
+- How often should models run (the `@daily` cron, or a different cadence)?
+- Where will the MotherDuck token come from (the `MOTHERDUCK_TOKEN` env var and `.dlt/secrets.toml`)?
+
+## Caveats
+
+- **Keep the two database names in sync.** SQLMesh reads the raw tables from the same MotherDuck database dlt wrote to. If `transform/config.yaml` `database` does not match the dlt destination database (`dlt_test_db` by default), `sqlmesh plan` will fail to resolve `stock_data.*`.
+- **Token must be in the right place for the right tool.** dlt reads the token from `.dlt/secrets.toml`; SQLMesh reads it from `MOTHERDUCK_TOKEN`. Setting only one will make the other step fail. Do not commit the token; keep it in `.dlt/secrets.toml` (gitignored) and your shell env, not in `config.yaml`.
+- **Regenerate external models after schema changes.** `external_models.yaml` is a static snapshot of the dlt output columns. `yfinance` periodically adds or renames `stock_info` fields, so a new load can drift from the declared schema. Re-run `sqlmesh create_external_models` after loads that change the raw shape, or SQLMesh will reference columns that no longer match.
+- **`write_disposition="replace"` is a full reload.** Every `dlt` run truncates and reloads the raw tables. The SCD type 2 history in SQLMesh comes from the `_dlt_load_time` snapshots, not from dlt itself, so you only capture change history if you load on a schedule (each load is one snapshot in time).
+- **`yfinance` is unofficial and rate-limited.** Symbols are validated with a 1-day history probe before fetching, and resources swallow per-symbol exceptions and print to stdout rather than failing the run. A symbol that returns no data is skipped silently, so check the load output if a ticker is missing downstream. Large symbol lists, especially option chains, can be slow and may hit Yahoo throttling.
+- **History defaults to a 360-day window.** `stock_history_resource` only pulls the trailing 360 days, while the incremental model's `start` is `'2023-01-01'`. Backfilling earlier than what dlt loaded produces empty slices, not older data; widen the dlt window first.
+- **The interim layer is hand-maintained typed SQL.** Each interim model casts every column explicitly (for example `close::DOUBLE`, `symbol::TEXT`). If you add tickers with new `stock_info` fields you want downstream, you must add the casts to the interim model yourself; the raw-to-interim mapping is not automatic.
+
 ## What you'll adjust
 
 | Setting | Purpose | Options / example |
@@ -96,14 +114,6 @@ The history loader coerces each OHLCV value defensively because `yfinance` may r
 | `cron` per model | How often SQLMesh refreshes the model | `'@daily'` on the interim, conformed, and full models |
 | `audits (...)` per model | Data quality checks enforced at run time | `UNIQUE_COMBINATION_OF_COLUMNS`, `NOT_NULL`, `UNIQUE_VALUES` |
 | `transform/external_models.yaml` | Declares the raw dlt tables (and their columns) as external sources | regenerate with `sqlmesh create_external_models` after a load |
-
-## Questions to answer
-
-- Which tickers or source dataset should the pipeline load (replace `symbols.txt`, or swap dlt for a different source)?
-- What MotherDuck database and schema are the target? Set both the dlt `destination` database and `transform/config.yaml` `database`, and keep them in sync.
-- Full refresh or incremental, and what is the backfill start date for time-based models?
-- How often should models run (the `@daily` cron, or a different cadence)?
-- Where will the MotherDuck token come from (the `MOTHERDUCK_TOKEN` env var and `.dlt/secrets.toml`)?
 
 ## Run it
 
@@ -143,16 +153,6 @@ If SQLMesh cannot find your token during `info`/`plan`, make sure `MOTHERDUCK_TO
 - [`transform/`](transform/) - the SQLMesh root, also holding empty scaffold dirs (`audits/`, `macros/`, `seeds/`, `tests/`) for project growth.
 - [`pyproject.toml`](pyproject.toml) - the uv project definition: pins dlt, duckdb, sqlmesh (with the web UI extra), and yfinance.
 - [`uv.lock`](uv.lock) - the pinned dependency lockfile for reproducible `uv sync`.
-
-## Caveats
-
-- **Keep the two database names in sync.** SQLMesh reads the raw tables from the same MotherDuck database dlt wrote to. If `transform/config.yaml` `database` does not match the dlt destination database (`dlt_test_db` by default), `sqlmesh plan` will fail to resolve `stock_data.*`.
-- **Token must be in the right place for the right tool.** dlt reads the token from `.dlt/secrets.toml`; SQLMesh reads it from `MOTHERDUCK_TOKEN`. Setting only one will make the other step fail. Do not commit the token; keep it in `.dlt/secrets.toml` (gitignored) and your shell env, not in `config.yaml`.
-- **Regenerate external models after schema changes.** `external_models.yaml` is a static snapshot of the dlt output columns. `yfinance` periodically adds or renames `stock_info` fields, so a new load can drift from the declared schema. Re-run `sqlmesh create_external_models` after loads that change the raw shape, or SQLMesh will reference columns that no longer match.
-- **`write_disposition="replace"` is a full reload.** Every `dlt` run truncates and reloads the raw tables. The SCD type 2 history in SQLMesh comes from the `_dlt_load_time` snapshots, not from dlt itself, so you only capture change history if you load on a schedule (each load is one snapshot in time).
-- **`yfinance` is unofficial and rate-limited.** Symbols are validated with a 1-day history probe before fetching, and resources swallow per-symbol exceptions and print to stdout rather than failing the run. A symbol that returns no data is skipped silently, so check the load output if a ticker is missing downstream. Large symbol lists, especially option chains, can be slow and may hit Yahoo throttling.
-- **History defaults to a 360-day window.** `stock_history_resource` only pulls the trailing 360 days, while the incremental model's `start` is `'2023-01-01'`. Backfilling earlier than what dlt loaded produces empty slices, not older data; widen the dlt window first.
-- **The interim layer is hand-maintained typed SQL.** Each interim model casts every column explicitly (for example `close::DOUBLE`, `symbol::TEXT`). If you add tickers with new `stock_info` fields you want downstream, you must add the casts to the interim model yourself; the raw-to-interim mapping is not automatic.
 
 ## Learn more
 

--- a/vercel-agent-analytics/README.md
+++ b/vercel-agent-analytics/README.md
@@ -42,14 +42,6 @@ Why this shape:
 - **Native MotherDuck table**: the simplest write path and the fastest reads. If you want open Parquet under the hood and snapshot isolation instead, see the DuckLake variant note in Caveats.
 - **Classifier in code, rules in YAML**: `bots.yaml` is the source of truth for AI identification. Update it and redeploy; the raw payload is stored on every row so you can reclassify history in SQL.
 
-## Security
-
-- **HMAC verification is mandatory.** `src/signature.ts` recomputes HMAC-SHA1 of the raw body with `VERCEL_DRAIN_SECRET` and compares it with the `x-vercel-signature` header using a constant-time `timingSafeEqual`. A missing or mismatched signature returns `401` and nothing is written. The secret in the Vercel drain config must match `VERCEL_DRAIN_SECRET` exactly, otherwise every delivery is rejected.
-- **Verification happens on the raw body before parsing.** Sign the unmodified body bytes; the local test script does this with `openssl dgst -sha1 -hmac`. Any middleware that re-serializes the body before it reaches the handler will break the signature.
-- **The collector builds SQL by string concatenation, not bound parameters.** String values are escaped via `sqlStr` (doubling single quotes) and identifiers via `quoteIdent` (doubling double quotes), and `MD_DESTINATION` is validated to be exactly `<database>.<schema>`. This is the trust boundary that keeps log content from breaking out of the `INSERT`. If you add columns or new value types, route them through `sqlStr` / `sqlTs` / `quoteIdent`, do not interpolate raw strings.
-- **Do not put secrets in `vercel.json` or commit them.** `MOTHERDUCK_TOKEN` and `VERCEL_DRAIN_SECRET` are read from the environment only.
-- **Client IPs are anonymized by default.** `anonymizeIp` zeroes the last IPv4 octet (`203.0.113.42` becomes `203.0.113.0`) before insert. IPv6 and non-IPv4 strings pass through unchanged, so adjust the function if you need IPv6 handling or full IPs for a legitimate reason.
-
 ## How it works
 
 - `src/signature.ts`: HMAC-SHA1 verification of the raw body, constant-time comparison.
@@ -84,11 +76,33 @@ Save `sql/02_dive_queries.sql` as a MotherDuck Dive. Each block is one tile:
 - Daily AI share of traffic, last 30 days.
 - Top pages by AI category, last 24h.
 
-The queries default to `agent_analytics.raw.vercel_request_logs`; if you changed `MD_DESTINATION` or `MD_TABLE`, update the identifiers in the file before saving it. For Dive authoring, sharing, and embedding, run the `get_dive_guide` MCP tool.
+The queries default to `agent_analytics.raw.vercel_request_logs`; if you changed `MD_DESTINATION` or `MD_TABLE`, update the identifiers in the file before saving it.
 
 ## When to turn on `BOTS_ONLY`
 
 Start with `BOTS_ONLY=false` so you have a real baseline that includes human traffic: you can measure AI share of traffic, see which pages humans land on from AI UIs, and so on. Flip it to `true` once the table has grown large enough that dropping non-AI rows is worth it. Because the raw payload is not retained for dropped rows, you cannot recover human traffic after the fact, so keep the baseline long enough first.
+
+## Questions to answer
+
+- Which Vercel project's traffic should be captured, and is there permission to create a log drain on it?
+- Target MotherDuck database and schema (`MD_DESTINATION`) and table name (`MD_TABLE`).
+- All traffic for a baseline, or AI-only (`BOTS_ONLY`)? Start with all traffic, see "When to turn on BOTS_ONLY".
+- Which AI crawlers, agents, and AI referers matter, so `bots.yaml` can be tuned.
+- Should client IPs be anonymized (the default) or kept in full.
+- Where the MotherDuck token and the shared drain secret will be stored as Vercel environment variables (never commit them to `vercel.json` or the repo).
+
+## Caveats
+
+- **Cold start**: the first invocation after idle pays a roughly 500 ms to 1 s MotherDuck extension load. Vercel Fluid Compute keeps functions warm well enough that this is rare in practice. For high-QPS sites, ping the function every few minutes or enable always-warm via Vercel's Fluid config.
+- **`HOME` can be empty on Vercel**: MotherDuck needs a writable extension cache. `src/db.ts` pins `HOME` and `DUCKDB_EXTENSION_DIRECTORY` to a temp path; if you change that code, keep it writable or the connection fails silently on cold start.
+- **Bundle size**: `@duckdb/node-api` ships a native binary. Fluid Compute gives you the headroom; classic Serverless Functions may hit the 50 MB zipped limit.
+- **No appender on native MotherDuck tables (yet)**: the example uses a multi-row `INSERT` instead. With roughly 500 rows per batch that is one network round-trip per drain POST, which is plenty fast. If you need the appender path or open Parquet storage with snapshot isolation, build the DuckLake variant of this collector instead (run `ask_docs_question` for DuckLake).
+- **At-least-once delivery**: on a 5xx response Vercel redelivers the batch, and the handler deliberately returns `503` on a failed write so Vercel retries. If you care about exact counts, dedupe on `event_id` in your queries.
+- **Agentic browsers that spoof user agents**: the classifier only sees what the bot tells it. AI agents using plain Chromium UAs fall into the `null` bucket and are counted as human unless their referer matches.
+- **`bots.yaml` must be bundled**: `vercel.json` sets `includeFiles: "bots.yaml"`. If you remove that, `src/classify.ts` throws "bots.yaml not found" at cold start and the function fails.
+- **Don't sign or transform the body before the handler**: signature verification runs on the raw bytes. Any body rewrite breaks the HMAC check and every delivery returns `401`.
+- **`INSERT` column order is load-bearing**: the value tuples in `src/db.ts` must match the `CREATE TABLE` order in `sql/01_setup.sql`. Adding a column means editing both, in the same order.
+- **`MD_DESTINATION` parsing is strict**: it must be exactly `<database>.<schema>` with two non-empty parts, or the function throws at cold start. A bare database name or a three-part name is rejected.
 
 ## What you'll adjust
 
@@ -105,15 +119,6 @@ Start with `BOTS_ONLY=false` so you have a real baseline that includes human tra
 | `anonymizeIp` (`src/handler.ts`) | Zeroes the last IPv4 octet before insert | remove or change if you need full IPs or IPv6 handling |
 | `maxDuration` / `includeFiles` (`vercel.json`) | Function timeout and which non-code files get bundled | `maxDuration: 30`; `includeFiles: "bots.yaml"` |
 | `PORT` (env, local only) | Port for the local dev harness `src/local-server.ts` | default `8787` |
-
-## Questions to answer
-
-- Which Vercel project's traffic should be captured, and is there permission to create a log drain on it?
-- Target MotherDuck database and schema (`MD_DESTINATION`) and table name (`MD_TABLE`).
-- All traffic for a baseline, or AI-only (`BOTS_ONLY`)? Start with all traffic, see "When to turn on BOTS_ONLY".
-- Which AI crawlers, agents, and AI referers matter, so `bots.yaml` can be tuned.
-- Should client IPs be anonymized (the default) or kept in full.
-- Where the MotherDuck token and the shared drain secret will be stored as Vercel environment variables (never commit them to `vercel.json` or the repo).
 
 ## Run it
 
@@ -160,6 +165,14 @@ SELECT * FROM agent_analytics.raw.vercel_request_logs
 ORDER BY event_ts DESC LIMIT 20;
 ```
 
+## Security
+
+- **HMAC verification is mandatory.** `src/signature.ts` recomputes HMAC-SHA1 of the raw body with `VERCEL_DRAIN_SECRET` and compares it with the `x-vercel-signature` header using a constant-time `timingSafeEqual`. A missing or mismatched signature returns `401` and nothing is written. The secret in the Vercel drain config must match `VERCEL_DRAIN_SECRET` exactly, otherwise every delivery is rejected.
+- **Verification happens on the raw body before parsing.** Sign the unmodified body bytes; the local test script does this with `openssl dgst -sha1 -hmac`. Any middleware that re-serializes the body before it reaches the handler will break the signature.
+- **The collector builds SQL by string concatenation, not bound parameters.** String values are escaped via `sqlStr` (doubling single quotes) and identifiers via `quoteIdent` (doubling double quotes), and `MD_DESTINATION` is validated to be exactly `<database>.<schema>`. This is the trust boundary that keeps log content from breaking out of the `INSERT`. If you add columns or new value types, route them through `sqlStr` / `sqlTs` / `quoteIdent`, do not interpolate raw strings.
+- **Do not put secrets in `vercel.json` or commit them.** `MOTHERDUCK_TOKEN` and `VERCEL_DRAIN_SECRET` are read from the environment only.
+- **Client IPs are anonymized by default.** `anonymizeIp` zeroes the last IPv4 octet (`203.0.113.42` becomes `203.0.113.0`) before insert. IPv6 and non-IPv4 strings pass through unchanged, so adjust the function if you need IPv6 handling or full IPs for a legitimate reason.
+
 ## Files
 
 - [`api/drain.ts`](api/drain.ts) - the Vercel Function entry point: reads the raw POST body, pulls the `x-vercel-signature` header, hands off to `handleDrain`, returns `405` for non-POST.
@@ -172,19 +185,6 @@ ORDER BY event_ts DESC LIMIT 20;
 - [`vercel.json`](vercel.json) - the Vercel Function config: `maxDuration: 30` and `includeFiles: "bots.yaml"` so the classifier rules get bundled.
 - [`package.json`](package.json) - dependencies (`@duckdb/node-api`, `yaml`) and scripts (`dev`, `typecheck`); `package-lock.json` pins the lockfile.
 - [`tsconfig.json`](tsconfig.json) - strict TypeScript config (ES2022, ESNext modules) covering `api/` and `src/`.
-
-## Caveats
-
-- **Cold start**: the first invocation after idle pays a roughly 500 ms to 1 s MotherDuck extension load. Vercel Fluid Compute keeps functions warm well enough that this is rare in practice. For high-QPS sites, ping the function every few minutes or enable always-warm via Vercel's Fluid config.
-- **`HOME` can be empty on Vercel**: MotherDuck needs a writable extension cache. `src/db.ts` pins `HOME` and `DUCKDB_EXTENSION_DIRECTORY` to a temp path; if you change that code, keep it writable or the connection fails silently on cold start.
-- **Bundle size**: `@duckdb/node-api` ships a native binary. Fluid Compute gives you the headroom; classic Serverless Functions may hit the 50 MB zipped limit.
-- **No appender on native MotherDuck tables (yet)**: the example uses a multi-row `INSERT` instead. With roughly 500 rows per batch that is one network round-trip per drain POST, which is plenty fast. If you need the appender path or open Parquet storage with snapshot isolation, build the DuckLake variant of this collector instead (run `ask_docs_question` for DuckLake).
-- **At-least-once delivery**: on a 5xx response Vercel redelivers the batch, and the handler deliberately returns `503` on a failed write so Vercel retries. If you care about exact counts, dedupe on `event_id` in your queries.
-- **Agentic browsers that spoof user agents**: the classifier only sees what the bot tells it. AI agents using plain Chromium UAs fall into the `null` bucket and are counted as human unless their referer matches.
-- **`bots.yaml` must be bundled**: `vercel.json` sets `includeFiles: "bots.yaml"`. If you remove that, `src/classify.ts` throws "bots.yaml not found" at cold start and the function fails.
-- **Don't sign or transform the body before the handler**: signature verification runs on the raw bytes. Any body rewrite breaks the HMAC check and every delivery returns `401`.
-- **`INSERT` column order is load-bearing**: the value tuples in `src/db.ts` must match the `CREATE TABLE` order in `sql/01_setup.sql`. Adding a column means editing both, in the same order.
-- **`MD_DESTINATION` parsing is strict**: it must be exactly `<database>.<schema>` with two non-empty parts, or the function throws at cold start. A bare database name or a three-part name is rejected.
 
 ## Learn more
 

--- a/vercel-nextjs/README.md
+++ b/vercel-nextjs/README.md
@@ -86,6 +86,78 @@ publicly trusted certificate, so no custom CA is needed. Do not set
 `rejectUnauthorized: false`; it disables verification and exposes the connection
 to man-in-the-middle attacks.
 
+## How it works
+
+- `src/lib/motherduck.ts`: the shared `pg.Pool`, the `attachDatabasePool`
+  cleanup hook, and the `withClient` checkout/release helper.
+- `src/app/api/trips/route.ts` and `src/app/api/stats/route.ts`: the two API
+  handlers, including the `YYYY-MM-DD` validation and the parameterized `$1`/`$2`
+  aggregate.
+
+## Questions to answer
+
+- Which MotherDuck database and schema should the routes read from (default is `sample_data.nyc.taxi`)?
+- Which region is the account in, so the right `MOTHERDUCK_HOST` is set (US vs EU)?
+- What tables and columns do the API routes need to expose, and what query parameters drive them?
+- How will the token be provisioned in production: manual `vercel env add` or the MotherDuck Native Integration on Vercel?
+- What concurrency is expected, so the pool `max` and idle timeout can be tuned?
+
+## Caveats
+
+- The token is a credential. Keep it in `.env.local` (gitignored) for local dev
+  and in Vercel environment variables for deploy. Do not commit it or expose it
+  in client-side code; these queries run only in server-side API routes.
+- `src/lib/motherduck.ts` throws at import time if `MOTHERDUCK_TOKEN` is unset.
+  Locally that surfaces immediately; on Vercel a missing variable fails the
+  function at runtime, so set the env var before relying on the routes.
+- The pool is module-level so it can be reused across warm invocations, but
+  serverless instances are not shared. Under burst traffic many instances each
+  open up to `max: 10` connections; size `max` against your MotherDuck plan's
+  connection limits rather than assuming a single global pool.
+- Identifiers (table and column names) cannot be parameterized with `$1`. Only
+  values can. If a route needs a dynamic table or column name, validate it
+  against an allow-list instead of interpolating user input.
+- The stats route binds dates as timestamp strings (`YYYY-MM-DD 00:00:00`), and
+  the regex enforces that shape. If you loosen the input format, keep the bound
+  value a type MotherDuck can compare against `tpep_pickup_datetime`, or the
+  query errors or returns nothing.
+- The `nyc.taxi` data is historical, so `ORDER BY tpep_pickup_datetime DESC` in
+  `/api/trips` returns the latest rows in the dataset, not today's trips. Pick a
+  date range that actually exists in the data when testing `/api/stats`.
+
+## What you'll adjust
+
+| Setting | Purpose | Options / example |
+| --- | --- | --- |
+| `MOTHERDUCK_TOKEN` env var | MotherDuck access token used as the connection password | Service-account token from your MotherDuck settings |
+| `MOTHERDUCK_HOST` env var | Postgres endpoint host, selects the region | `pg.us-east-1-aws.motherduck.com` (default), `pg.eu-central-1-aws.motherduck.com` for EU |
+| `MOTHERDUCK_DB` env var | Database in the connection string | `sample_data` (default), or your own database |
+| `connectionString` in `src/lib/motherduck.ts` | How the pool authenticates, fixed at port `5432` | `postgresql://user:${token}@${host}:5432/${db}` |
+| Pool options in `src/lib/motherduck.ts` | Pooling behavior for serverless concurrency | `max: 10`, `idleTimeoutMillis: 5000` |
+| `ssl` option in `src/lib/motherduck.ts` | TLS verification level | `{ rejectUnauthorized: true }` (equivalent to `sslmode=verify-full`) |
+| SQL in `src/app/api/trips/route.ts` | The "recent trips" query and row limit | Change `FROM nyc.taxi`, columns, `LIMIT 20` |
+| SQL in `src/app/api/stats/route.ts` | The aggregate query and its `$1`/`$2` date params | Swap the table, columns, and the `datePattern` validation regex |
+
+## Run it
+
+Prerequisites: Node.js v18+, a MotherDuck account and access token, and (for deploy) a Vercel account.
+
+```sh
+npm install
+cp .env.local.example .env.local   # then set MOTHERDUCK_TOKEN
+npm run dev                         # http://localhost:3000
+```
+
+Build and deploy to Vercel:
+
+```sh
+npm run build
+npx vercel deploy
+npx vercel env add MOTHERDUCK_TOKEN   # if not using the MotherDuck Native Integration
+```
+
+If you install the [MotherDuck Native Integration](https://vercel.com/marketplace/motherduck) on Vercel, the access token is injected as an environment variable automatically.
+
 ## Security
 
 Always sanitize anything that comes from a request before it reaches SQL. This
@@ -123,47 +195,6 @@ const result = await client.query(
 );
 ```
 
-## What you'll adjust
-
-| Setting | Purpose | Options / example |
-| --- | --- | --- |
-| `MOTHERDUCK_TOKEN` env var | MotherDuck access token used as the connection password | Service-account token from your MotherDuck settings |
-| `MOTHERDUCK_HOST` env var | Postgres endpoint host, selects the region | `pg.us-east-1-aws.motherduck.com` (default), `pg.eu-central-1-aws.motherduck.com` for EU |
-| `MOTHERDUCK_DB` env var | Database in the connection string | `sample_data` (default), or your own database |
-| `connectionString` in `src/lib/motherduck.ts` | How the pool authenticates, fixed at port `5432` | `postgresql://user:${token}@${host}:5432/${db}` |
-| Pool options in `src/lib/motherduck.ts` | Pooling behavior for serverless concurrency | `max: 10`, `idleTimeoutMillis: 5000` |
-| `ssl` option in `src/lib/motherduck.ts` | TLS verification level | `{ rejectUnauthorized: true }` (equivalent to `sslmode=verify-full`) |
-| SQL in `src/app/api/trips/route.ts` | The "recent trips" query and row limit | Change `FROM nyc.taxi`, columns, `LIMIT 20` |
-| SQL in `src/app/api/stats/route.ts` | The aggregate query and its `$1`/`$2` date params | Swap the table, columns, and the `datePattern` validation regex |
-
-## Questions to answer
-
-- Which MotherDuck database and schema should the routes read from (default is `sample_data.nyc.taxi`)?
-- Which region is the account in, so the right `MOTHERDUCK_HOST` is set (US vs EU)?
-- What tables and columns do the API routes need to expose, and what query parameters drive them?
-- How will the token be provisioned in production: manual `vercel env add` or the MotherDuck Native Integration on Vercel?
-- What concurrency is expected, so the pool `max` and idle timeout can be tuned?
-
-## Run it
-
-Prerequisites: Node.js v18+, a MotherDuck account and access token, and (for deploy) a Vercel account.
-
-```sh
-npm install
-cp .env.local.example .env.local   # then set MOTHERDUCK_TOKEN
-npm run dev                         # http://localhost:3000
-```
-
-Build and deploy to Vercel:
-
-```sh
-npm run build
-npx vercel deploy
-npx vercel env add MOTHERDUCK_TOKEN   # if not using the MotherDuck Native Integration
-```
-
-If you install the [MotherDuck Native Integration](https://vercel.com/marketplace/motherduck) on Vercel, the access token is injected as an environment variable automatically.
-
 ## Files
 
 - [`src/lib/motherduck.ts`](src/lib/motherduck.ts) - the shared `pg.Pool` (reads `MOTHERDUCK_TOKEN`/`MOTHERDUCK_HOST`/`MOTHERDUCK_DB`), the `attachDatabasePool` cleanup hook, and the `withClient` checkout/release helper.
@@ -174,35 +205,7 @@ If you install the [MotherDuck Native Integration](https://vercel.com/marketplac
 - [`next.config.ts`](next.config.ts) - Next.js config (currently empty defaults).
 - [`tsconfig.json`](tsconfig.json) - TypeScript config, including the `@/*` to `src/*` path alias.
 
-## Caveats
+## Learn more
 
-- The token is a credential. Keep it in `.env.local` (gitignored) for local dev
-  and in Vercel environment variables for deploy. Do not commit it or expose it
-  in client-side code; these queries run only in server-side API routes.
-- `src/lib/motherduck.ts` throws at import time if `MOTHERDUCK_TOKEN` is unset.
-  Locally that surfaces immediately; on Vercel a missing variable fails the
-  function at runtime, so set the env var before relying on the routes.
-- The pool is module-level so it can be reused across warm invocations, but
-  serverless instances are not shared. Under burst traffic many instances each
-  open up to `max: 10` connections; size `max` against your MotherDuck plan's
-  connection limits rather than assuming a single global pool.
-- Identifiers (table and column names) cannot be parameterized with `$1`. Only
-  values can. If a route needs a dynamic table or column name, validate it
-  against an allow-list instead of interpolating user input.
-- The stats route binds dates as timestamp strings (`YYYY-MM-DD 00:00:00`), and
-  the regex enforces that shape. If you loosen the input format, keep the bound
-  value a type MotherDuck can compare against `tpep_pickup_datetime`, or the
-  query errors or returns nothing.
-- The `nyc.taxi` data is historical, so `ORDER BY tpep_pickup_datetime DESC` in
-  `/api/trips` returns the latest rows in the dataset, not today's trips. Pick a
-  date range that actually exists in the data when testing `/api/stats`.
-
-## How it works / Learn more
-
-- `src/lib/motherduck.ts`: the shared `pg.Pool`, the `attachDatabasePool`
-  cleanup hook, and the `withClient` checkout/release helper.
-- `src/app/api/trips/route.ts` and `src/app/api/stats/route.ts`: the two API
-  handlers, including the `YYYY-MM-DD` validation and the parameterized `$1`/`$2`
-  aggregate.
 - Postgres endpoint reference: [authenticating and connecting via the Postgres endpoint](https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/postgres-endpoint).
 - For deeper MotherDuck or DuckDB SQL questions, use the `ask_docs_question` MCP tool or the MotherDuck docs.


### PR DESCRIPTION
Reorders catalog README bodies and flight template READMEs so How it works, Questions, Caveats, What you'll adjust, Run it, Security, and Learn more appear in the requested reader-first sequence.
Updates the root authoring guidance and the MotherDuck examples skill to document the new structure.
Splits combined How it works / Learn more sections and keeps MCP tool references in Caveats/Learn more, including a Flight SQL surface cleanup in the SQL transformation template.
Validated with `uv run scripts/build-catalog.py`, catalog preview/schema validation, and the catalog pytest suite.
