### PR TITLE
Add example catalog categories

### DIFF
--- a/.agents/skills/motherduck-examples/SKILL.md
+++ b/.agents/skills/motherduck-examples/SKILL.md
@@ -59,7 +59,7 @@ sync, GitHub Pages, or committed generated JSON.
 ## README Metadata
 
 Catalog READMEs start with YAML front matter. For catalog entries, keep exactly
-these six keys:
+these seven keys:
 
 ```yaml
 ---
@@ -69,6 +69,7 @@ description: >-
   Query public Hacker News Parquet data in S3 and build dbt models. Use when a
   user wants to ingest S3/Parquet with dbt, run locally or on MotherDuck.
 type: example
+category: ingestion
 features: []
 tags: [dbt]
 ---
@@ -78,6 +79,11 @@ Rules:
 
 - `id` must match the folder name.
 - `type` is `example` or `template`.
+- `category` is the single primary navigation bucket for the entry. It must be
+  one of `getting-started`, `ingestion`, `analytics`, `integrations`,
+  `end-to-end`, or `automation`. Pick by primary intent: a Flight that ingests
+  data is `ingestion`, while a Flight that sends operational alerts is
+  `automation`; `flights` remains a feature, not a category.
 - `features` is a subset of the MotherDuck capabilities the code actually uses:
   `admin_api`, `dives`, `ducklake`, `flights`, `mcp`, `pg_duckdb`, `pg_endpoint`,
   `shares`, `wasm`. Use `pg_endpoint` for the MotherDuck Postgres wire endpoint

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ injects it as `MOTHERDUCK_TOKEN`.
 
 ## Anatomy of an example
 
-Every example README starts with YAML front matter holding exactly six keys:
+Every example README starts with YAML front matter holding exactly seven keys:
 
 ```yaml
 ---
@@ -87,6 +87,7 @@ description: >-
   One or two sentences on what it does, then a "Use when ..." clause so an
   agent can route to it.
 type: example                   # example | template
+category: ingestion             # one primary navigation category (see list below)
 features: []                    # MotherDuck capabilities used; [] if none (see list below)
 tags: [dbt]                     # curated lowercase slugs: significant third-party tools
 ---
@@ -94,6 +95,9 @@ tags: [dbt]                     # curated lowercase slugs: significant third-par
 
 - `type` is `example` (a concrete, worked instance) or `template` (a generic plan
   an agent parameterizes).
+- `category` is one primary navigation bucket: `getting-started`, `ingestion`,
+  `analytics`, `integrations`, `end-to-end`, or `automation`. Pick by primary
+  intent: Flights are categorized by what they do, not by being Flights.
 - `features` names the MotherDuck capabilities the code actually uses, from:
   `admin_api`, `dives`, `ducklake`, `flights`, `mcp`, `pg_duckdb`, `pg_endpoint`,
   `shares`, `wasm`. Note `pg_endpoint` (MotherDuck's Postgres wire endpoint) and

--- a/catalog.schema.json
+++ b/catalog.schema.json
@@ -64,6 +64,7 @@
         "type",
         "title",
         "description",
+        "category",
         "features",
         "tags",
         "path",
@@ -86,6 +87,16 @@
         "description": {
           "type": "string",
           "minLength": 1
+        },
+        "category": {
+          "enum": [
+            "getting-started",
+            "ingestion",
+            "analytics",
+            "integrations",
+            "end-to-end",
+            "automation"
+          ]
         },
         "features": {
           "type": "array",

--- a/cloudflare-workers-duckoffee/README.md
+++ b/cloudflare-workers-duckoffee/README.md
@@ -8,6 +8,7 @@ description: >-
   full-stack edge app that queries MotherDuck without bundling DuckDB and keeps a
   small piece of real-time shared state at the edge.
 type: example
+category: end-to-end
 features: [pg_endpoint, shares]
 tags: [cloudflare, durable-objects, node-postgres, d3, typescript]
 ---

--- a/cloudflare-workers/README.md
+++ b/cloudflare-workers/README.md
@@ -7,6 +7,7 @@ description: >-
   want a serverless HTTP API or edge endpoint that reads from MotherDuck and
   returns JSON.
 type: example
+category: integrations
 features: [pg_endpoint]
 tags: [cloudflare, typescript, node-postgres]
 ---

--- a/dbt-ai-prompt/README.md
+++ b/dbt-ai-prompt/README.md
@@ -8,6 +8,7 @@ description: >-
   to run inside a dbt model as a normal SQL transformation, with no external
   API code.
 type: example
+category: analytics
 features: [shares]
 tags: [dbt]
 ---

--- a/dbt-churn-prediction/README.md
+++ b/dbt-churn-prediction/README.md
@@ -7,6 +7,7 @@ description: >-
   scores a churn model on top. Use when you need a SQL-first churn feature
   pipeline on MotherDuck, with model training kept as a separate step.
 type: example
+category: analytics
 features: []
 tags: [dbt, python, scikit-learn]
 ---

--- a/dbt-dual-execution/README.md
+++ b/dbt-dual-execution/README.md
@@ -8,6 +8,7 @@ description: >-
   sample dbt models locally against a local file while still reading from (and
   writing to) MotherDuck, without maintaining two separate projects.
 type: example
+category: analytics
 features: []
 tags: [dbt]
 ---

--- a/dbt-duckdb-dwh-starter/README.md
+++ b/dbt-duckdb-dwh-starter/README.md
@@ -7,6 +7,7 @@ description: >-
   tables. Use when you want a from-scratch dbt warehouse on MotherDuck and a
   worked example of shipping a Dive on top of dbt models.
 type: example
+category: analytics
 features: [dives, shares]
 tags: [dbt]
 ---

--- a/dbt-ducklake/README.md
+++ b/dbt-ducklake/README.md
@@ -7,6 +7,7 @@ description: >-
   database. Use when you want a dbt project that lands raw tables in DuckLake
   storage and writes analytics models to native MotherDuck.
 type: example
+category: analytics
 features: [ducklake]
 tags: [dbt]
 ---

--- a/dbt-ingestion-s3/README.md
+++ b/dbt-ingestion-s3/README.md
@@ -7,6 +7,7 @@ description: >-
   when you want a dbt-on-MotherDuck recipe that reads Parquet/CSV directly from
   object storage without copying it first.
 type: example
+category: ingestion
 features: []
 tags: [dbt]
 ---

--- a/dbt-local-ducklake/README.md
+++ b/dbt-local-ducklake/README.md
@@ -8,6 +8,7 @@ description: >-
   compaction) for local dbt development that mirrors a managed DuckLake on
   MotherDuck.
 type: example
+category: analytics
 features: [ducklake]
 tags: [dbt, postgres, sqlite]
 ---

--- a/dbt-metricflow/README.md
+++ b/dbt-metricflow/README.md
@@ -7,6 +7,7 @@ description: >-
   MotherDuck. Use when you want one metric definition (revenue, order count,
   derived ratios) that runs identically on a local file and in the cloud.
 type: example
+category: analytics
 features: []
 tags: [dbt, metricflow]
 ---

--- a/dlt-db-replication/README.md
+++ b/dlt-db-replication/README.md
@@ -7,6 +7,7 @@ description: >-
   refresh tables from a source SQL database into MotherDuck and want tunable
   extract, normalize, and load parallelism.
 type: example
+category: ingestion
 features: []
 tags: [dlt, postgres, connectorx]
 ---

--- a/flight-plans/flight-bigquery-ingest/README.md
+++ b/flight-plans/flight-bigquery-ingest/README.md
@@ -10,6 +10,7 @@ description: >-
   GoogleSQL. Use when you want scheduled, incremental BigQuery to MotherDuck
   ingestion as part of a migration off BigQuery.
 type: template
+category: ingestion
 features: [flights]
 tags: [bigquery, ingest, migrate]
 ---

--- a/flight-plans/flight-dive-usage-metrics/README.md
+++ b/flight-plans/flight-dive-usage-metrics/README.md
@@ -9,6 +9,7 @@ description: >-
   you want a scheduled, trend-aware map of which data objects your Dives lean on
   and how they connect.
 type: template
+category: analytics
 features: [flights, dives]
 tags: []
 ---

--- a/flight-plans/flight-dlt-ingest/README.md
+++ b/flight-plans/flight-dlt-ingest/README.md
@@ -7,6 +7,7 @@ description: >-
   Python ingestion that handles API calls, schema drift, state, and merge
   behavior without hand-writing every INSERT.
 type: template
+category: ingestion
 features: [flights]
 tags: [dlt, ingest]
 ---

--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -7,6 +7,7 @@ description: >-
   when you want scheduled freshness monitoring on MotherDuck tables with a
   warn/error severity model and a Slack notification.
 type: template
+category: automation
 features: [flights]
 tags: [slack]
 ---

--- a/flight-plans/flight-postgres-ingest/README.md
+++ b/flight-plans/flight-postgres-ingest/README.md
@@ -8,6 +8,7 @@ description: >-
   with backoff, and a per-table audit log. Use it for a config-driven, re-runnable
   Postgres to MotherDuck ingest.
 type: template
+category: ingestion
 features: [flights]
 tags: [postgres, ingest, migrate]
 ---

--- a/flight-plans/flight-provision-user-databases/README.md
+++ b/flight-plans/flight-provision-user-databases/README.md
@@ -7,6 +7,7 @@ description: >-
   for inactive users. Use when an application gives each user their own database
   and share, and access should follow an active/inactive flag.
 type: template
+category: automation
 features: [flights, shares]
 tags: []
 ---

--- a/flight-plans/flight-scheduled-s3-ingest/README.md
+++ b/flight-plans/flight-scheduled-s3-ingest/README.md
@@ -7,6 +7,7 @@ description: >-
   files already land in partitioned object storage and you want a scheduled,
   incremental warehouse refresh without re-reading every partition each run.
 type: template
+category: ingestion
 features: [flights]
 tags: [ingest, s3]
 ---

--- a/flight-plans/flight-snowflake-ingest/README.md
+++ b/flight-plans/flight-snowflake-ingest/README.md
@@ -8,6 +8,7 @@ description: >-
   MotherDuck ingest with a control table you can curate, for example as part of
   a migration off Snowflake.
 type: template
+category: ingestion
 features: [flights]
 tags: [snowflake, ingest, migrate]
 ---

--- a/flight-plans/flight-sql-transformation/README.md
+++ b/flight-plans/flight-sql-transformation/README.md
@@ -8,6 +8,7 @@ description: >-
   and each retries with exponential backoff. 
   Use for a set of SQL transformations inside one Flight.
 type: template
+category: analytics
 features: [flights]
 tags: []
 ---

--- a/motherduck-grafana/README.md
+++ b/motherduck-grafana/README.md
@@ -7,6 +7,7 @@ description: >-
   SQL. Use when you want to build Grafana dashboards or time-series panels on top
   of MotherDuck data.
 type: example
+category: integrations
 features: []
 tags: [grafana, docker]
 ---

--- a/motherduck-ui/README.md
+++ b/motherduck-ui/README.md
@@ -7,6 +7,7 @@ description: >-
   in the MotherDuck web UI. Use when you want a hands-on intro to interactive data
   exploration and ad hoc cleaning in MotherDuck without writing application code.
 type: example
+category: getting-started
 features: []
 tags: []
 ---

--- a/nba-box-scores/README.md
+++ b/nba-box-scores/README.md
@@ -8,6 +8,7 @@ description: >-
   live. Use when you want a worked example of pairing a scheduled Flight ingest
   with a Dive built and deployed as code.
 type: example
+category: end-to-end
 features: [flights, dives]
 tags: [python, typescript]
 ---

--- a/nodejs-motherduck/README.md
+++ b/nodejs-motherduck/README.md
@@ -8,6 +8,7 @@ description: >-
   Node.js app or service that can ship the DuckDB binary, including concurrent
   workloads that need pooled connections.
 type: example
+category: getting-started
 features: []
 tags: [nodejs, javascript, generic-pool]
 ---

--- a/postgres-demo/README.md
+++ b/postgres-demo/README.md
@@ -7,6 +7,7 @@ description: >-
   tables from psql. Use when you want a hybrid Postgres plus MotherDuck setup
   where one side reads the other, not a serverless app talking to MotherDuck.
 type: example
+category: integrations
 features: [pg_duckdb]
 tags: [postgres, docker]
 ---

--- a/python-ingestion/README.md
+++ b/python-ingestion/README.md
@@ -7,6 +7,7 @@ description: >-
   PyArrow path. Use when you need a standalone Python ingestion script that pulls
   from an API or in-memory dataframe and writes to MotherDuck.
 type: example
+category: ingestion
 features: []
 tags: [python, pyarrow, pandas]
 ---

--- a/scripts/build-catalog.py
+++ b/scripts/build-catalog.py
@@ -5,10 +5,10 @@
 
 """Validate README front matter and build the examples catalog.
 
-Every catalog entry is a README.md with YAML front matter holding exactly six
-keys: title, id, description, type, features, tags. Running this script with no
-output path validates the front matter across the repo (non-zero exit on the
-first problem). Pass --output to also write catalog.json.
+Every catalog entry is a README.md with YAML front matter holding exactly seven
+keys: title, id, description, type, category, features, tags. Running this script
+with no output path validates the front matter across the repo (non-zero exit on
+the first problem). Pass --output to also write catalog.json.
 """
 
 from __future__ import annotations
@@ -27,6 +27,14 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 ALLOWED_TYPES = {"example", "template"}
+ALLOWED_CATEGORIES = {
+    "getting-started",
+    "ingestion",
+    "analytics",
+    "integrations",
+    "end-to-end",
+    "automation",
+}
 ALLOWED_FEATURES = {
     "admin_api",
     "dives",
@@ -82,8 +90,16 @@ ALLOWED_TAGS = {
     "ingest",
     "migrate",
 }
-ALLOWED_KEYS = {"title", "id", "description", "type", "features", "tags"}
-REQUIRED_KEYS = {"title", "id", "description", "type"}
+ALLOWED_KEYS = {
+    "title",
+    "id",
+    "description",
+    "type",
+    "category",
+    "features",
+    "tags",
+}
+REQUIRED_KEYS = {"title", "id", "description", "type", "category"}
 FLIGHT_PLANS_DIR = "flight-plans"
 
 SKIPPED_DIR_NAMES = {
@@ -196,6 +212,12 @@ def build_item(
             f"{readme_path}: type must be one of {sorted(ALLOWED_TYPES)}"
         )
 
+    category = assert_string(frontmatter, readme_path, "category")
+    if category not in ALLOWED_CATEGORIES:
+        raise CatalogError(
+            f"{readme_path}: category must be one of {sorted(ALLOWED_CATEGORIES)}"
+        )
+
     features = assert_slug_list(frontmatter, readme_path, "features")
     unknown_features = set(features) - ALLOWED_FEATURES
     if unknown_features:
@@ -237,6 +259,7 @@ def build_item(
         "type": item_type,
         "title": assert_string(frontmatter, readme_path, "title"),
         "description": assert_string(frontmatter, readme_path, "description"),
+        "category": category,
         "features": features,
         "tags": tags,
         "path": relative_dir,

--- a/sqlmesh-demo/README.md
+++ b/sqlmesh-demo/README.md
@@ -7,6 +7,7 @@ description: >-
   SCD type 2, audits, virtual data environments). Use when you want a SQLMesh
   project on MotherDuck, or a dlt-to-SQLMesh ELT pipeline to adapt.
 type: example
+category: analytics
 features: []
 tags: [sqlmesh, dlt]
 ---

--- a/statsbomb-360-football-matches/README.md
+++ b/statsbomb-360-football-matches/README.md
@@ -9,6 +9,7 @@ description: >-
   multi-stage Flight pipeline (raw -> core -> marts, transformed with in-warehouse
   SQL) paired with a bespoke D3 Dive deployed as code.
 type: example
+category: end-to-end
 features: [flights, dives]
 tags: [python, typescript, d3]
 ---

--- a/tests/test_build_catalog.py
+++ b/tests/test_build_catalog.py
@@ -31,6 +31,7 @@ title: Ingest API data into MotherDuck with Python
 id: python-ingestion
 description: Load API data into MotherDuck from Python.
 type: example
+category: ingestion
 features: []
 tags:
   - python
@@ -69,6 +70,7 @@ type: example
             "type": "example",
             "title": "Ingest API data into MotherDuck with Python",
             "description": "Load API data into MotherDuck from Python.",
+            "category": "ingestion",
             "features": [],
             "tags": ["python", "pyarrow"],
             "path": "python-ingestion",
@@ -108,6 +110,7 @@ title: Duplicate
 id: duplicate
 description: Duplicate IDs should not be allowed.
 type: example
+category: integrations
 """,
         )
 
@@ -126,6 +129,7 @@ title: Ingest API data into MotherDuck with Python
 id: python-ingestion
 description: Load API data into MotherDuck from Python.
 type: example
+category: ingestion
 categories:
   - ingestion
 """,
@@ -148,6 +152,7 @@ title: Build Hacker News Models From S3 With dbt
 id: dbt-ingestion-s3
 description: A dbt example that can deploy as a Flight.
 type: example
+category: ingestion
 features:
   - flights
 tags:
@@ -169,6 +174,7 @@ title: Build Hacker News Models From S3 With dbt
 id: dbt-ingestion-s3
 description: A concrete example should not live under flight-plans.
 type: example
+category: ingestion
 features:
   - flights
 tags:
@@ -192,6 +198,7 @@ title: Run Any dbt Project as a MotherDuck Flight
 id: dbt-runner
 description: Run dbt as a MotherDuck Flight.
 type: template
+category: automation
 features:
   - flights
 tags:
@@ -206,3 +213,44 @@ tags:
 
     Draft202012Validator.check_schema(schema)
     Draft202012Validator(schema).validate(catalog)
+
+
+def test_missing_category_fails(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    write_readme(
+        repo_root / "python-ingestion" / "README.md",
+        """
+title: Ingest API data into MotherDuck with Python
+id: python-ingestion
+description: Load API data into MotherDuck from Python.
+type: example
+features: []
+tags: [python]
+""",
+    )
+
+    with pytest.raises(
+        build_catalog_module.CatalogError, match="missing required keys .*category"
+    ):
+        build_catalog_module.build_catalog(repo_root)
+
+
+def test_unknown_category_fails(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    write_readme(
+        repo_root / "python-ingestion" / "README.md",
+        """
+title: Ingest API data into MotherDuck with Python
+id: python-ingestion
+description: Load API data into MotherDuck from Python.
+type: example
+category: etl
+features: []
+tags: [python]
+""",
+    )
+
+    with pytest.raises(
+        build_catalog_module.CatalogError, match="category must be one of"
+    ):
+        build_catalog_module.build_catalog(repo_root)

--- a/vercel-agent-analytics/README.md
+++ b/vercel-agent-analytics/README.md
@@ -8,6 +8,7 @@ description: >-
   Use when you want to measure AI bot, agent, and AI-referred human traffic to a
   Vercel-hosted site and query it live from a Dive or any SQL tool, with no AWS or S3.
 type: example
+category: end-to-end
 features: []
 tags: [vercel, nodejs, typescript]
 ---

--- a/vercel-nextjs/README.md
+++ b/vercel-nextjs/README.md
@@ -7,6 +7,7 @@ description: >-
   (or any Node serverless) backend that reads MotherDuck data through pooled,
   parameterized SQL.
 type: example
+category: integrations
 features: [pg_endpoint]
 tags: [vercel, nextjs, node-postgres]
 ---


### PR DESCRIPTION
Adds a required `category` front matter field to all 30 catalog entries using the canonical getting-started, ingestion, analytics, integrations, end-to-end, and automation buckets. Updates the catalog builder, JSON schema, tests, root README, and local agent guidance so generated catalog items include and validate the new field. Validated locally with catalog generation, schema validation, pytest, and ruff.