### PR TITLE
Add Google Sheets two-way sync Flight plan

### DIFF
--- a/flight-plans/flight-google-sheets/README.md
+++ b/flight-plans/flight-google-sheets/README.md
@@ -3,27 +3,25 @@ title: Sync Google Sheets and MotherDuck With a Flight
 id: flight-google-sheets
 description: >-
   A reusable Flight that syncs data both ways between Google Sheets and
-  MotherDuck through the DuckDB gsheets community extension: import a list of
+  MotherDuck through the DuckDB gsheets community extension. Import a list of
   sheets into MotherDuck tables, and export query results back to sheet tabs as
   reverse ETL. Both directions are full-refresh and idempotent, with per-item
   retries and an audit log. Use it to pull business data out of spreadsheets and
   push curated data back into them for business process automation.
 type: template
-category: integrations
+category: ingestion
 features: [flights]
-tags: [google-sheets, ingest]
+tags: [google-sheets, ingest, export]
 ---
 
 # Sync Google Sheets and MotherDuck With a Flight
 
-Spreadsheets are where a lot of real business data actually lives — budgets a
-finance team maintains by hand, a list of target accounts sales is working,
-vendor terms, headcount plans, regional price overrides. This Flight brings that
-data into MotherDuck so it can join your warehouse tables, and pushes results
-back out to Google Sheets so the people who live in spreadsheets keep working
+Spreadsheets are where a lot of real business data actually lives. 
+This Flight brings that data into MotherDuck so it can join your warehouse tables, 
+and pushes results back out to Google Sheets so the people who live in spreadsheets keep working
 where they already are.
 
-The "push back out" direction is **reverse ETL**: you run a query in MotherDuck
+The export direction is **reverse ETL**: you run a query in MotherDuck
 and land the result on a Google Sheet tab. That is what turns a warehouse into
 **business process automation** — a scheduled Flight can refresh a "top accounts
 to call today" tab, a per-region inventory sheet, or a finance reconciliation
@@ -33,8 +31,7 @@ ingest, a pure reverse-ETL publish, or a full round trip.
 
 At a high level you give the Flight two lists: which sheets to **import** (each
 becomes a MotherDuck table) and which queries to **export** (each result
-overwrites a sheet tab). Everything else — credentials, retries, the audit log —
-is handled for you.
+overwrites a sheet tab).
 
 ## How it works
 
@@ -43,15 +40,11 @@ for the common cases. One run does:
 
 1. **Validate config and credentials, then connect.** The Google service-account
    key is read from a MotherDuck **Flights secret** and registered with the
-   `gsheets` extension **in memory** (never written to disk). Bad config or a
-   missing key exits cleanly before any work is attempted.
+   `gsheets` extension **in memory**.
 2. **Import each configured sheet** with one atomic statement:
    `CREATE OR REPLACE TABLE <db>.<schema>.<table> AS SELECT * FROM read_gsheet('<url>')`.
-   This runs on the MotherDuck connection (the extension executes client-side),
-   so it is ATOMIC (swaps in one step), IDEMPOTENT (no watermark to drift), and
-   STREAMING.
 3. **Export each configured query** by running the SELECT on MotherDuck,
-   materializing the (sheet-sized) result as an Arrow table, and copying it to
+   materializing the (small sheet-sized) result as an Arrow table, and copying it to
    the destination tab with `COPY ... TO '<url>' (FORMAT gsheet, OVERWRITE_SHEET TRUE)`.
    `OVERWRITE_SHEET` keeps re-runs idempotent.
 4. **Isolate, retry, and audit every item.** Each import/export is retried with
@@ -59,11 +52,6 @@ for the common cases. One run does:
    item — success or failure — is recorded in
    `<TARGET_DATABASE>.main.gsheets_sync_log`, and the run exits non-zero if
    anything failed after retries.
-
-Sheet writes use a second, local DuckDB connection on purpose: `COPY (FORMAT
-gsheet)` cannot be resolved on a connection with the MotherDuck extension loaded,
-so the import side runs on `md:` and the export's final write runs locally, with
-an Arrow table bridging the two.
 
 ## Questions to answer
 
@@ -83,13 +71,11 @@ an Arrow table bridging the two.
 
 - **Service accounts have zero Drive storage quota** (Google policy since 2025),
   so the service account cannot create or own spreadsheets. Every source and
-  destination sheet must be owned by a person (or a Shared Drive) and **shared
-  with the service account's `client_email`**: Viewer is enough for sources,
+  destination sheet must be owned by a person (or a Shared Drive) and shared
+  with the service account's `client_email`: **Viewer** is enough for sources,
   **Editor** for destinations.
 - **Full refresh, both directions.** Imports replace the whole table; exports
-  overwrite the whole tab. Updates and deletes are reflected, but this is not an
-  append/CDC pattern — for very large or high-churn tables, use a different
-  template.
+  overwrite the whole tab. 
 - **Destination sheets must exist** unless the export sets `create_sheet: true`,
   which creates the tab if missing.
 - **Sheet size limits.** A Google spreadsheet holds at most 10M cells; exports
@@ -135,8 +121,13 @@ EXPORTS = [
 ## Run it
 
 You need a MotherDuck account and token, and a Google service-account key whose
-`client_email` has been shared on the sheets you reference. For a local run,
-inject the key the same way the Flights secret would:
+`client_email` has been shared on the sheets you reference. 
+
+To create and set up a Google service-account and key, ask your agent! Or use these references:
+* [DuckDB GSheets extension docs for getting a token](https://duckdb-gsheets.com/#getting-a-google-api-access-token)
+* [Docs for creating a Google Service Account](https://docs.cloud.google.com/iam/docs/service-accounts-create)
+
+For a local run, inject the key the same way the Flights secret would:
 
 ```bash
 export MOTHERDUCK_TOKEN=your_token_here
@@ -190,8 +181,7 @@ user whether a schedule is desired and what cadence fits the data.
 
 - **Key in a secret, in memory only.** The service-account key comes from a `TYPE
   flights` secret and is registered with the extension inline (`EMAIL`/`SECRET`),
-  never written to disk and never logged. Plain Flight `config` is not treated as
-  sensitive, so the key never goes there.
+  never written to disk and never logged.
 - **Quoted identifiers and escaped literals.** Config-supplied database/schema/
   table names flow into SQL via `quote_ident()`, and sheet URLs/options via a
   single-quote-escaping `sql_str()` — preventing SQL injection.

--- a/flight-plans/flight-google-sheets/README.md
+++ b/flight-plans/flight-google-sheets/README.md
@@ -1,0 +1,206 @@
+---
+title: Sync Google Sheets and MotherDuck With a Flight
+id: flight-google-sheets
+description: >-
+  A reusable Flight that syncs data both ways between Google Sheets and
+  MotherDuck through the DuckDB gsheets community extension: import a list of
+  sheets into MotherDuck tables, and export query results back to sheet tabs as
+  reverse ETL. Both directions are full-refresh and idempotent, with per-item
+  retries and an audit log. Use it to pull business data out of spreadsheets and
+  push curated data back into them for business process automation.
+type: template
+category: integrations
+features: [flights]
+tags: [google-sheets, ingest]
+---
+
+# Sync Google Sheets and MotherDuck With a Flight
+
+Spreadsheets are where a lot of real business data actually lives — budgets a
+finance team maintains by hand, a list of target accounts sales is working,
+vendor terms, headcount plans, regional price overrides. This Flight brings that
+data into MotherDuck so it can join your warehouse tables, and pushes results
+back out to Google Sheets so the people who live in spreadsheets keep working
+where they already are.
+
+The "push back out" direction is **reverse ETL**: you run a query in MotherDuck
+and land the result on a Google Sheet tab. That is what turns a warehouse into
+**business process automation** — a scheduled Flight can refresh a "top accounts
+to call today" tab, a per-region inventory sheet, or a finance reconciliation
+report every morning, with no one exporting CSVs by hand. The same Flight can do
+the inbound direction, the outbound direction, or both, so it fits a plain
+ingest, a pure reverse-ETL publish, or a full round trip.
+
+At a high level you give the Flight two lists: which sheets to **import** (each
+becomes a MotherDuck table) and which queries to **export** (each result
+overwrites a sheet tab). Everything else — credentials, retries, the audit log —
+is handled for you.
+
+## How it works
+
+`flight.py` is a single file driven entirely by config; no code edits are needed
+for the common cases. One run does:
+
+1. **Validate config and credentials, then connect.** The Google service-account
+   key is read from a MotherDuck **Flights secret** and registered with the
+   `gsheets` extension **in memory** (never written to disk). Bad config or a
+   missing key exits cleanly before any work is attempted.
+2. **Import each configured sheet** with one atomic statement:
+   `CREATE OR REPLACE TABLE <db>.<schema>.<table> AS SELECT * FROM read_gsheet('<url>')`.
+   This runs on the MotherDuck connection (the extension executes client-side),
+   so it is ATOMIC (swaps in one step), IDEMPOTENT (no watermark to drift), and
+   STREAMING.
+3. **Export each configured query** by running the SELECT on MotherDuck,
+   materializing the (sheet-sized) result as an Arrow table, and copying it to
+   the destination tab with `COPY ... TO '<url>' (FORMAT gsheet, OVERWRITE_SHEET TRUE)`.
+   `OVERWRITE_SHEET` keeps re-runs idempotent.
+4. **Isolate, retry, and audit every item.** Each import/export is retried with
+   jittered exponential backoff; one failing item never stops the rest. Every
+   item — success or failure — is recorded in
+   `<TARGET_DATABASE>.main.gsheets_sync_log`, and the run exits non-zero if
+   anything failed after retries.
+
+Sheet writes use a second, local DuckDB connection on purpose: `COPY (FORMAT
+gsheet)` cannot be resolved on a connection with the MotherDuck extension loaded,
+so the import side runs on `md:` and the export's final write runs locally, with
+an Arrow table bridging the two.
+
+## Questions to answer
+
+- Which Google Sheets should become MotherDuck tables, and what table name does
+  each map to? (Optionally a specific tab, cell range, header handling, and a
+  per-item destination database/schema.)
+- Which queries should be published back to Sheets, and to which spreadsheet URL
+  and tab? (Each export is either a `query` or a `database`/`table` reference.)
+- Are you doing import-only, export-only, or both? Leave the unused list blank.
+- Which `TARGET_DATABASE` / `TARGET_SCHEMA` should imported tables land in?
+- What schedule (cron, UTC) matches how often the source data changes and how
+  fresh the published sheets need to be?
+- Which Google service account will the sheets be shared with? (See
+  [Caveats](#caveats) — service accounts cannot own sheets.)
+
+## Caveats
+
+- **Service accounts have zero Drive storage quota** (Google policy since 2025),
+  so the service account cannot create or own spreadsheets. Every source and
+  destination sheet must be owned by a person (or a Shared Drive) and **shared
+  with the service account's `client_email`**: Viewer is enough for sources,
+  **Editor** for destinations.
+- **Full refresh, both directions.** Imports replace the whole table; exports
+  overwrite the whole tab. Updates and deletes are reflected, but this is not an
+  append/CDC pattern — for very large or high-churn tables, use a different
+  template.
+- **Destination sheets must exist** unless the export sets `create_sheet: true`,
+  which creates the tab if missing.
+- **Sheet size limits.** A Google spreadsheet holds at most 10M cells; exports
+  are capped at 10,000,000 rows to bound memory, and wider results can still hit
+  the cell cap at the Sheets API. The extension also writes ~2,048 rows per API
+  call with no rate-limit retry, so very large exports can hit Google's
+  per-minute write quota.
+- **Export queries must be a single read-only `SELECT`** (enforced by DuckDB's
+  parser); `database`/`schema`/`limit` apply only in table mode.
+- **Old tables/tabs are not removed.** Dropping a sheet from `SOURCE_SHEETS` does
+  not drop the table it created; clean those up yourself.
+
+## What you'll adjust
+
+No code edits are required. Everything is read from Flight config/env plus one
+MotherDuck **Flights secret** holding the Google service-account key.
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `SOURCE_SHEETS` | `[]` | JSON array of sheets to import. Each: `{"url", "table"}` plus optional `sheet`, `range`, `header`, `all_varchar`, `database`, `schema`. Leave blank for export-only. |
+| `EXPORTS` | `[]` | JSON array of queries to publish. Each: `{"url"}` plus EITHER `query` (one SELECT) OR `database`+`table` (optional `schema`, `limit`); optional `sheet`, `create_sheet`. Leave blank for import-only. |
+| `TARGET_DATABASE` | `google_sheets` | MotherDuck database imported tables land in (created if absent). Also holds the `gsheets_sync_log` audit table. |
+| `TARGET_SCHEMA` | `main` | Schema imported tables land in. |
+| `GSHEETS_SECRET_NAME` | `gsheets` | Name of the `TYPE flights` secret holding `SERVICE_ACCOUNT_JSON`. |
+| `MAX_RETRIES` | `5` | Per-item retry attempts. |
+| `RETRY_BASE_SECONDS` | `2` | Exponential-backoff multiplier (seconds). |
+| `MOTHERDUCK_HOST` | (unset) | Override MotherDuck host (non-prod). Leave unset for default. |
+| `gsheets` **secret** | (required) | `TYPE flights` secret with one param, `SERVICE_ACCOUNT_JSON`, holding the full service-account key JSON. |
+
+Example config values:
+
+```json
+SOURCE_SHEETS = [
+  {"url": "https://docs.google.com/spreadsheets/d/<id>/edit", "table": "target_accounts"},
+  {"url": "https://docs.google.com/spreadsheets/d/<id>/edit", "table": "price_overrides", "sheet": "Q3"}
+]
+EXPORTS = [
+  {"url": "https://docs.google.com/spreadsheets/d/<id>/edit", "sheet": "calls_today", "create_sheet": true,
+   "query": "SELECT account, owner, score FROM crm.scored_accounts ORDER BY score DESC LIMIT 200"}
+]
+```
+
+## Run it
+
+You need a MotherDuck account and token, and a Google service-account key whose
+`client_email` has been shared on the sheets you reference. For a local run,
+inject the key the same way the Flights secret would:
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+# the service-account key JSON, exactly as the `gsheets` Flights secret injects it:
+export gsheets_SERVICE_ACCOUNT_JSON="$(cat path/to/service-account.json)"
+# pick a direction (either, or both):
+export SOURCE_SHEETS='[{"url":"https://docs.google.com/spreadsheets/d/<id>/edit","table":"target_accounts"}]'
+export EXPORTS='[{"url":"https://docs.google.com/spreadsheets/d/<id>/edit","sheet":"calls_today","create_sheet":true,"query":"SELECT 1 AS demo"}]'
+# optional: destination database/schema
+# export TARGET_DATABASE=google_sheets
+uv run --with-requirements requirements.txt flight.py
+```
+
+This validates config and the key, connects to MotherDuck, loads the `gsheets`
+extension, creates `TARGET_DATABASE` and the `main.gsheets_sync_log` audit table,
+then imports each sheet and exports each query with per-item retries. One log
+line per item plus a summary; exits non-zero if any item failed after retries.
+
+### Deploy as a Flight
+
+First store the Google service-account key as a **Flights secret** named
+`gsheets` (UI: [Settings > Secrets](https://app.motherduck.com/settings/secrets),
+type **Flights**). Or via SQL from a write-enabled connection (read-only
+connections reject `CREATE SECRET`):
+
+```sql
+CREATE SECRET gsheets IN motherduck (
+  TYPE flights,
+  PARAMS MAP { 'SERVICE_ACCOUNT_JSON': '<paste the full service-account key JSON>' }
+);
+```
+
+Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments to your situation), passing:
+
+- `name`: a Flight name, for example `google_sheets_sync`
+- `source_code`: [`flight.py`](flight.py) (no edits for the common cases)
+- `requirements_txt`: [`requirements.txt`](requirements.txt)
+- `flight_secret_names`: `["gsheets"]` so the service-account key is injected
+- `config`: your `SOURCE_SHEETS` and/or `EXPORTS` JSON, plus `TARGET_DATABASE`/`TARGET_SCHEMA` if non-default. Credentials stay in the `gsheets` secret, never config.
+
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed.
+
+Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`), and confirm
+`<TARGET_DATABASE>.main.gsheets_sync_log` has one row per item. Decide with the
+user whether a schedule is desired and what cadence fits the data.
+
+## Security
+
+- **Key in a secret, in memory only.** The service-account key comes from a `TYPE
+  flights` secret and is registered with the extension inline (`EMAIL`/`SECRET`),
+  never written to disk and never logged. Plain Flight `config` is not treated as
+  sensitive, so the key never goes there.
+- **Quoted identifiers and escaped literals.** Config-supplied database/schema/
+  table names flow into SQL via `quote_ident()`, and sheet URLs/options via a
+  single-quote-escaping `sql_str()` — preventing SQL injection.
+- **Read-only export queries.** Each export `query` is validated with DuckDB's
+  parser to be exactly one `SELECT`, so an export can never mutate the warehouse.
+
+## Learn more
+
+- Flight mechanics (create, run, schedule, secrets): MCP `get_flight_guide`.
+- DuckDB `gsheets` extension: [github.com/evidence-dev/duckdb_gsheets](https://github.com/evidence-dev/duckdb_gsheets).
+- Deeper MotherDuck/DuckDB questions: MCP `ask_docs_question`.
+- Files: [`flight.py`](flight.py) (the Flight source), [`requirements.txt`](requirements.txt) (`duckdb` plus `pyarrow` for the export Arrow bridge and `tenacity` for retry/backoff; the `gsheets` extension is a runtime community extension, not a pip package).

--- a/flight-plans/flight-google-sheets/flight.py
+++ b/flight-plans/flight-google-sheets/flight.py
@@ -1,0 +1,505 @@
+"""Google Sheets <-> MotherDuck two-way sync flight.
+
+Configure a list of Google Sheets to import to MotherDuck and/or
+a list of queries to run and export to Google Sheets. 
+This uses the GSheets DuckDB Community Extension. 
+
+Import from Google Sheets with a single SQL statement:
+    CREATE OR REPLACE TABLE <db>.<schema>.<table> AS SELECT * FROM read_gsheet('<url>');
+
+Export to Google Sheets by running a MotherDuck query, exporting in-memory to Apache Arrow, 
+then copying from Arrow to Google Sheets (still with the GSheets extension). 
+
+Both import and export are a full-refresh operation. 
+Each import and export is retried on errors.
+Success or failure is logged in an audit log in <target>.main.gsheets_sync_log.
+
+Config (env vars):
+    Secret `GSHEETS_SECRET_NAME` (default gsheets) injects
+    `<name>_SERVICE_ACCOUNT_JSON`: a Google service-account key (never expires;
+    the extension mints short-lived OAuth tokens from it). Share each sheet with
+    its client_email (Viewer for sources, Editor for destinations).
+    TARGET_DATABASE - import destination database (default google_sheets)
+    TARGET_SCHEMA - import destination schema (default main).
+    SOURCE_SHEETS     - JSON array of objects: {"url": ..., "table": ...} plus optional
+        sheet, range, header, all_varchar, database, schema.
+    EXPORTS           - JSON array of objects: {"url": ...} plus EITHER "query" (exactly one
+        SELECT) OR "database"+"table" (optional schema, default main, and limit);
+        optional sheet and create_sheet.
+    MAX_RETRIES (5) 
+    RETRY_BASE_SECONDS (2)
+
+Exit codes: 0 = all items succeeded; 1 = some failed after retries (everything
+was attempted); 2 = bad config/credentials/setup (nothing attempted).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import partial
+
+import duckdb
+from tenacity import (
+    Retrying,
+    stop_after_attempt,
+    wait_exponential,
+    wait_random,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("gsheets_sync")
+
+# docs.google.com spreadsheet URL (incl. the /u/<n>/ account-switcher form) or a
+# bare sheet ID (Google IDs are 44 chars).
+SHEET_URL_RE = re.compile(
+    r"^(https://docs\.google\.com/spreadsheets/(u/\d+/)?d/[A-Za-z0-9_-]{10,}([/?#].*)?"
+    r"|[A-Za-z0-9_-]{40,})$"
+)
+
+# 10M = the Google Sheets per-spreadsheet CELL limit, i.e. the most rows any sheet
+# could hold (1-column case). Bounds the Arrow materialization in run_export;
+# multi-column results above 10M/column_count cells still fail at the Sheets API.
+GSHEETS_MAX_ROWS = 10_000_000
+
+ALLOWED_IMPORT_KEYS = {"url", "table", "sheet", "range", "header", "all_varchar", "database", "schema"}
+ALLOWED_EXPORT_KEYS = {"url", "sheet", "query", "database", "schema", "table", "limit", "create_sheet"}
+
+SYNC_LOG_COLUMNS = (
+    "run_id", "direction", "item_key", "source_ref", "target_ref",
+    "rows", "attempts", "status", "error", "started_at", "finished_at",
+)
+
+
+class ConfigError(ValueError):
+    """Malformed SOURCE_SHEETS / EXPORTS config; aborts before any work."""
+
+
+# ---- Small SQL / env helpers ----
+def utcnow() -> datetime:
+    """Naive UTC: a tz-aware datetime written to a naive TIMESTAMP column gets
+    shifted by the client session's time zone, interleaving container/laptop runs."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def quote_ident(ident: str) -> str:
+    """Double-quote a SQL identifier the way DuckDB expects."""
+    return '"' + ident.replace('"', '""') + '"'
+
+
+def sql_str(value: str) -> str:
+    """Single-quoted DuckDB string literal for spots that can't be parameterized
+    (read_gsheet args, COPY targets). Refuses non-strings rather than laundering them."""
+    if not isinstance(value, str):
+        raise TypeError(f"sql_str() requires a string, got {type(value).__name__}")
+    return "'" + value.replace("'", "''") + "'"
+
+
+# ---- Config parsing / validation ----
+@dataclass(frozen=True)
+class SheetImport:
+    """One Google Sheet to import as a MotherDuck table."""
+    url: str
+    table: str
+    sheet: str | None = None
+    cell_range: str | None = None
+    header: bool | None = None
+    all_varchar: bool = False
+    database: str | None = None  # resolved destination (TARGET_DATABASE / TARGET_SCHEMA
+    schema: str | None = None    # default, or per-item override), set by parse_source_sheets
+
+    @property
+    def unique_id(self) -> str:
+        # The resolved target table, which parse_source_sheets guarantees unique.
+        return f"{self.database}.{self.schema}.{self.table}"
+
+
+@dataclass(frozen=True)
+class SheetExport:
+    """One MotherDuck SELECT to push out to a Google Sheet tab."""
+    url: str
+    sheet: str | None = None
+    query: str | None = None
+    database: str | None = None
+    schema: str | None = None
+    table: str | None = None
+    limit: int | None = None
+    create_sheet: bool = False
+
+    @property
+    def unique_id(self) -> str:
+        # The destination tab, which parse_exports guarantees unique.
+        return f"{self.url} -> sheet={self.sheet or '<first>'}"
+
+
+def _str_field(item: dict, key: str, idx: int, kind: str, required: bool = False) -> str | None:
+    """String field; a present non-string is a config typo that must fail fast (exit 2)."""
+    value = item.get(key)
+    if value is None and not required:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        msg = (f"required key {key!r} is missing or not a non-empty string" if required
+               else f"{key!r} must be a non-empty string when present")
+        raise ConfigError(f"{kind}[{idx}]: {msg}")
+    return value.strip()
+
+
+def _bool_field(item: dict, key: str, idx: int, kind: str, default: bool | None = None) -> bool | None:
+    """Optional boolean. Absent -> `default`; a present non-bool (incl. JSON null) is
+    a config typo that fails fast, uniformly across fields."""
+    if key not in item:
+        return default
+    if not isinstance(item[key], bool):
+        raise ConfigError(f"{kind}[{idx}]: {key!r} must be a boolean")
+    return item[key]
+
+
+def _parse_items(raw: str, kind: str, allowed: set[str], build) -> list:
+    """Shared SOURCE_SHEETS/EXPORTS scaffolding: JSON list of objects, no unknown
+    keys, valid sheet url; then build(item, url, idx) -> spec. Blank -> empty list,
+    so an unused direction can be left blank."""
+    raw = raw.strip() or "[]"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"{kind} is not valid JSON: {exc}") from exc
+    if not isinstance(data, list):
+        raise ConfigError(f"{kind} must be a JSON list, got {type(data).__name__}")
+    specs = []
+    for idx, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ConfigError(f"{kind}[{idx}]: every entry must be a JSON object")
+        if unknown := set(item) - allowed:
+            raise ConfigError(f"{kind}[{idx}]: unknown key(s) {sorted(unknown)}; allowed: {sorted(allowed)}")
+        url = _str_field(item, "url", idx, kind, required=True)
+        if not SHEET_URL_RE.match(url):
+            raise ConfigError(f"{kind}[{idx}]: {url!r} is not a docs.google.com spreadsheet URL or sheet ID")
+        specs.append(build(item, url, idx))
+    return specs
+
+
+def parse_source_sheets(raw: str, default_db: str, default_schema: str) -> list[SheetImport]:
+    """SOURCE_SHEETS -> SheetImport specs. Duplicate RESOLVED targets (same
+    db.schema.table after defaults apply) are rejected so typos can't clobber a table."""
+    def build(item: dict, url: str, idx: int) -> SheetImport:
+        return SheetImport(
+            url=url,
+            table=_str_field(item, "table", idx, "SOURCE_SHEETS", required=True),
+            sheet=_str_field(item, "sheet", idx, "SOURCE_SHEETS"),
+            cell_range=_str_field(item, "range", idx, "SOURCE_SHEETS"),
+            header=_bool_field(item, "header", idx, "SOURCE_SHEETS"),
+            all_varchar=_bool_field(item, "all_varchar", idx, "SOURCE_SHEETS", default=False),
+            database=_str_field(item, "database", idx, "SOURCE_SHEETS") or default_db,
+            schema=_str_field(item, "schema", idx, "SOURCE_SHEETS") or default_schema,
+        )
+
+    specs = _parse_items(raw, "SOURCE_SHEETS", ALLOWED_IMPORT_KEYS, build)
+    seen: set[tuple[str, str, str]] = set()
+    for spec in specs:
+        target = (spec.database, spec.schema, spec.table)
+        if target in seen:
+            raise ConfigError(f"SOURCE_SHEETS: duplicate target table {'.'.join(target)!r}")
+        seen.add(target)
+    return specs
+
+
+def validate_select(sql: str, idx: int) -> str:
+    """Exactly one SELECT, judged by DuckDB's own parser (prefix checks miss
+    WITH-prefixed DML and reject legitimate parenthesized/comment-prefixed queries)."""
+    try:
+        stmts = duckdb.extract_statements(sql)
+    except duckdb.Error as exc:
+        raise ConfigError(f"EXPORTS[{idx}]: 'query' does not parse: {exc}") from exc
+    if len(stmts) != 1 or stmts[0].type != duckdb.StatementType.SELECT:
+        raise ConfigError(f"EXPORTS[{idx}]: 'query' must be exactly one SELECT statement")
+    return sql.strip().rstrip(";").strip()
+
+
+def parse_exports(raw: str) -> list[SheetExport]:
+    """EXPORTS -> SheetExport specs: destination url plus exactly one of `query` or
+    `database`/`table`. Duplicate url+tab destinations would silently clobber each
+    other, so they're rejected."""
+    def build(item: dict, url: str, idx: int) -> SheetExport:
+        query, table, database, schema = item.get("query"), item.get("table"), None, None
+        if (query is None) == (table is None):
+            raise ConfigError(f"EXPORTS[{idx}]: provide exactly one of 'query' or 'table'")
+        if query is not None:
+            query = validate_select(query, idx)
+            if {"database", "schema", "limit"} & item.keys():
+                raise ConfigError(
+                    f"EXPORTS[{idx}]: 'database'/'schema'/'limit' only apply in 'table' mode; "
+                    "qualify names and LIMIT inside the query instead"
+                )
+        else:
+            table = _str_field(item, "table", idx, "EXPORTS", required=True)
+            database = _str_field(item, "database", idx, "EXPORTS", required=True)
+            schema = _str_field(item, "schema", idx, "EXPORTS")
+        limit = item.get("limit")
+        if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0):
+            raise ConfigError(f"EXPORTS[{idx}]: 'limit' must be a positive integer")
+        return SheetExport(
+            url=url,
+            sheet=_str_field(item, "sheet", idx, "EXPORTS"),
+            query=query, database=database, schema=schema, table=table, limit=limit,
+            create_sheet=_bool_field(item, "create_sheet", idx, "EXPORTS", default=False),
+        )
+
+    specs = _parse_items(raw, "EXPORTS", ALLOWED_EXPORT_KEYS, build)
+    seen: set[tuple[str, str]] = set()
+    for spec in specs:
+        dest = (spec.url, spec.sheet or "<first>")
+        if dest in seen:
+            raise ConfigError(f"EXPORTS: duplicate destination {dest[0]} sheet={dest[1]}")
+        seen.add(dest)
+    return specs
+
+
+# ---- SQL builders (pure functions -> unit-testable) ----
+def build_read_gsheet_sql(spec: SheetImport) -> str:
+    """read_gsheet() call for one import; it can't take bound parameters, so
+    everything is escaped into the SQL text."""
+    args = [sql_str(spec.url)]
+    if spec.sheet:
+        args.append(f"sheet={sql_str(spec.sheet)}")
+    if spec.cell_range:
+        args.append(f"range={sql_str(spec.cell_range)}")
+    if spec.header is not None:
+        args.append(f"header={'true' if spec.header else 'false'}")
+    if spec.all_varchar:
+        args.append("all_varchar=true")
+    return f"SELECT * FROM read_gsheet({', '.join(args)})"
+
+
+def build_export_query(spec: SheetExport) -> str:
+    """The SELECT run against MotherDuck: the user's validated query verbatim, or
+    SELECT * over the configured table with an optional LIMIT."""
+    if spec.query is not None:
+        return spec.query
+    fqtn = ".".join(quote_ident(part) for part in (spec.database, spec.schema or "main", spec.table))
+    sql = f"SELECT * FROM {fqtn}"
+    if spec.limit:
+        sql += f" LIMIT {spec.limit}"
+    return sql
+
+
+def build_copy_sql(spec: SheetExport, source_sql: str) -> str:
+    """COPY ... TO (FORMAT gsheet); OVERWRITE_SHEET keeps re-runs idempotent."""
+    opts = ["FORMAT gsheet"]
+    if spec.sheet:
+        opts.append(f"SHEET {sql_str(spec.sheet)}")
+    if spec.create_sheet:
+        opts.append("CREATE_IF_NOT_EXISTS TRUE")
+    opts.append("OVERWRITE_SHEET TRUE")
+    return f"COPY (SELECT * FROM {source_sql}) TO {sql_str(spec.url)} ({', '.join(opts)})"
+
+
+# ---- Connections + auth ----
+def validate_service_account_json(secret_name: str) -> tuple[str, str]:
+    """Pre-flight credential check, run BEFORE any connection so a missing/garbled
+    secret exits 2 with a clean error. Returns (client_email, private_key)."""
+    env_var = f"{secret_name}_SERVICE_ACCOUNT_JSON"
+    sa_json = os.environ.get(env_var)
+    if not sa_json:
+        raise RuntimeError(
+            f"Env var {env_var} is not set. Provide a `{secret_name}` flights secret "
+            "with a SERVICE_ACCOUNT_JSON param holding a Google service-account key."
+        )
+    try:
+        parsed = json.loads(sa_json)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{env_var} is not valid JSON (check the flight secret)") from exc
+    missing = {"client_email", "private_key"} - set(parsed)
+    if missing:
+        raise RuntimeError(
+            f"{env_var} is missing key(s) {sorted(missing)}; "
+            "expected a Google service-account key file"
+        )
+    return parsed["client_email"], parsed["private_key"]
+
+
+def create_gsheet_secret(con: duckdb.DuckDBPyConnection, email: str, private_key: str) -> None:
+    """Register the service-account key with the gsheets extension, in memory only:
+    the key is passed inline (EMAIL/SECRET), never written to disk."""
+    con.execute(
+        f"CREATE OR REPLACE SECRET gsheet_auth "
+        f"(TYPE gsheet, PROVIDER key_file, EMAIL {sql_str(email)}, SECRET {sql_str(private_key)})"
+    )
+
+
+# ---- Target setup + audit log ----
+def ensure_sync_log(md: duckdb.DuckDBPyConnection, database: str) -> None:
+    """Create the audit table and verify its schema up front: a pre-existing table
+    with drifted columns would silently kill every audit INSERT, so die loudly
+    (exit 2, before any work)."""
+    md.execute(f"CREATE DATABASE IF NOT EXISTS {quote_ident(database)}")
+    log_table = f"{quote_ident(database)}.main.gsheets_sync_log"
+    md.execute(
+        f"CREATE TABLE IF NOT EXISTS {log_table} ("
+        "run_id VARCHAR, direction VARCHAR, item_key VARCHAR, source_ref VARCHAR, "
+        "target_ref VARCHAR, rows BIGINT, attempts INTEGER, status VARCHAR, "
+        "error VARCHAR, started_at TIMESTAMP, finished_at TIMESTAMP)"
+    )
+    actual = tuple(d[0] for d in md.execute(f"SELECT * FROM {log_table} LIMIT 0").description)
+    if actual != SYNC_LOG_COLUMNS:
+        raise RuntimeError(
+            f"{log_table} exists with unexpected columns {list(actual)}; "
+            f"expected {list(SYNC_LOG_COLUMNS)}. Rename or migrate it."
+        )
+
+
+def record_result(md: duckdb.DuckDBPyConnection, log_db: str, row: list) -> None:
+    """Append one audit row (ordered as SYNC_LOG_COLUMNS). Audit failures are
+    logged but never abort the run - observability, not control."""
+    try:
+        md.execute(
+            f"INSERT INTO {quote_ident(log_db)}.main.gsheets_sync_log "
+            f"({', '.join(SYNC_LOG_COLUMNS)}) VALUES ({', '.join('?' * len(SYNC_LOG_COLUMNS))})",
+            row,
+        )
+    except Exception as exc:  # noqa: BLE001 - audit must not kill the job
+        log.warning("Could not write gsheets_sync_log row for %s: %s", row[2], exc)
+
+
+# ---- Per-item work (each call is retried as a unit; both are idempotent) ----
+def run_import(md: duckdb.DuckDBPyConnection, spec: SheetImport) -> tuple[str, int]:
+    """One sheet -> MotherDuck table as a single atomic CTAS. Database/schema
+    creation lives here (not main) so a bad per-item override fails THIS item only.
+    Returns (fully-qualified target, row count); safe to retry: the swap is atomic."""
+    db, schema = quote_ident(spec.database), quote_ident(spec.schema)
+    md.execute(f"CREATE DATABASE IF NOT EXISTS {db}")
+    md.execute(f"CREATE SCHEMA IF NOT EXISTS {db}.{schema}")
+    target = f"{db}.{schema}.{quote_ident(spec.table)}"
+    rows = md.execute(
+        f"CREATE OR REPLACE TABLE {target} AS {build_read_gsheet_sql(spec)}"
+    ).fetchone()[0]
+    return spec.unique_id, rows
+
+
+def run_export(
+    md: duckdb.DuckDBPyConnection, local: duckdb.DuckDBPyConnection, spec: SheetExport,
+) -> tuple[str, int]:
+    """One MotherDuck SELECT -> sheet tab via an in-memory Arrow bridge.
+    to_arrow_table(), not arrow(): the latter is a single-use RecordBatchReader in
+    duckdb 1.5+. Returns (destination, rows); safe to retry: the tab is overwritten."""
+    # .sql().limit() composes a LIMIT onto the user's query, bounding the Arrow
+    # materialization at the Sheets cell limit so a runaway query can't eat memory.
+    arrow_tbl = md.sql(build_export_query(spec)).limit(GSHEETS_MAX_ROWS).to_arrow_table()
+    if arrow_tbl.num_rows == GSHEETS_MAX_ROWS:
+        log.warning("Export %s hit the %d-row cap (Google Sheets cell limit); "
+                    "result may be truncated", spec.unique_id, GSHEETS_MAX_ROWS)
+    local.register("_gsheets_out", arrow_tbl)
+    try:
+        local.execute(build_copy_sql(spec, "_gsheets_out"))
+    finally:
+        local.unregister("_gsheets_out")
+    return f"{spec.url} (sheet={spec.sheet or '<first>'})", arrow_tbl.num_rows
+
+
+def setup_connections(secret_name: str, target_db: str) -> tuple:
+    """Validate credentials, open both connections, register gsheet auth, and ensure
+    the audit table. Raises on any failure so main() can exit 2 (nothing attempted).
+    Returns (md, local, client_email)."""
+    client_email, private_key = validate_service_account_json(secret_name)
+    md = duckdb.connect("md:")
+    local = duckdb.connect()  # sheet writes only: COPY (FORMAT gsheet) is
+    # unresolvable on any connection with the motherduck extension loaded.
+    for con in (md, local):
+        con.execute("INSTALL gsheets FROM community")
+        con.execute("LOAD gsheets")
+        create_gsheet_secret(con, client_email, private_key)
+    ensure_sync_log(md, target_db)
+    return md, local, client_email
+
+
+# ---- main ----
+def main() -> None:
+    """Parse config and validate credentials,
+    set up connections and the audit table, 
+    then run each import and export item with retries and isolation."""
+    RUN_ID = str(uuid.uuid4())
+    # `or default` so a blank env var falls back to the default, not an empty string.
+    TARGET_DB = os.environ.get("TARGET_DATABASE") or "google_sheets"
+    TARGET_SCHEMA = os.environ.get("TARGET_SCHEMA") or "main"
+    SECRET_NAME = os.environ.get("GSHEETS_SECRET_NAME") or "gsheets"
+
+    # ValueError (bad MAX_RETRIES/RETRY_BASE_SECONDS) is config-class -> exit 2, not a
+    # runtime traceback; ConfigError subclasses ValueError, so one except covers both.
+    try:
+        MAX_RETRIES = int(os.environ.get("MAX_RETRIES") or "5")
+        RETRY_BASE_SECONDS = float(os.environ.get("RETRY_BASE_SECONDS") or "2")
+        imports = parse_source_sheets(os.environ.get("SOURCE_SHEETS", "[]"), TARGET_DB, TARGET_SCHEMA)
+        exports = parse_exports(os.environ.get("EXPORTS", "[]"))
+    except ValueError as exc:
+        log.error("Configuration error: %s", exc)
+        sys.exit(2)
+
+    log.info("Run %s: %d import(s), %d export(s) -> target %s.%s",
+             RUN_ID, len(imports), len(exports), TARGET_DB, TARGET_SCHEMA)
+
+    if not imports and not exports:
+        log.warning("SOURCE_SHEETS and EXPORTS are both empty - nothing to do.")
+        return
+
+    try:
+        md, local, client_email = setup_connections(SECRET_NAME, TARGET_DB)
+    except Exception as exc:  # noqa: BLE001 - setup failure = nothing attempted = exit 2
+        log.error("Setup failed before any item was attempted: %s", exc)
+        sys.exit(2)
+    log.info("Google Sheets auth ready as %s", client_email)
+
+    started_all = utcnow()
+    failed: list[str] = []
+    succeeded = 0
+    rows_total = 0
+
+    work = [("import", s, partial(run_import, md, s)) for s in imports] \
+        + [("export", s, partial(run_export, md, local, s)) for s in exports]
+    for direction, spec, job in work:
+        # source_ref computed up front so success and failure audit rows match.
+        source_ref = spec.url if direction == "import" else build_export_query(spec)
+        started = utcnow()
+        # Jittered exponential backoff capped at 60s, retrying on any error.
+        retryer = Retrying(
+            stop=stop_after_attempt(MAX_RETRIES),
+            wait=wait_exponential(multiplier=RETRY_BASE_SECONDS, max=60) + wait_random(0, 1),
+            reraise=True,
+        )
+        try:
+            target_ref, rows = retryer(job)
+            status, error = "OK", None
+            succeeded += 1
+            rows_total += rows
+        except Exception as exc:  # noqa: BLE001 - per-item isolation is intentional
+            target_ref, rows, status = "", None, "FAILED"
+            error = f"{type(exc).__name__}: {exc}"
+            failed.append(f"{direction}:{spec.unique_id}")
+        attempts = retryer.statistics.get("attempt_number", 1)
+        record_result(md, TARGET_DB, [RUN_ID, direction, spec.unique_id, source_ref, target_ref,
+                                      rows, attempts, status, error and error[:4000],
+                                      started, utcnow()])
+        if status == "OK":
+            log.info("OK   %-6s %-60s %10d rows (attempts=%d)", direction, spec.unique_id, rows, attempts)
+        else:
+            log.error("FAIL %-6s %-60s (attempts=%d) %s", direction, spec.unique_id, attempts, error)
+
+    total_seconds = (utcnow() - started_all).total_seconds()
+    log.info("Summary: %d succeeded, %d failed, %d rows in %.1fs (run %s)",
+             succeeded, len(failed), rows_total, total_seconds, RUN_ID)
+
+    if failed:
+        log.error("Failed items: %s", ", ".join(failed))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/flight-plans/flight-google-sheets/requirements.txt
+++ b/flight-plans/flight-google-sheets/requirements.txt
@@ -1,4 +1,4 @@
-duckdb==1.5.2
+duckdb==1.5.3
 # pyarrow bridges the export direction: a MotherDuck query result is materialized
 # as an Arrow table in the Flight container, then handed to a local DuckDB
 # connection that writes it to Google Sheets. The `gsheets` extension itself is a

--- a/flight-plans/flight-google-sheets/requirements.txt
+++ b/flight-plans/flight-google-sheets/requirements.txt
@@ -1,0 +1,10 @@
+duckdb==1.5.2
+# pyarrow bridges the export direction: a MotherDuck query result is materialized
+# as an Arrow table in the Flight container, then handed to a local DuckDB
+# connection that writes it to Google Sheets. The `gsheets` extension itself is a
+# DuckDB community extension loaded at runtime (INSTALL gsheets FROM community),
+# not a pip package, so it is not listed here.
+pyarrow==24.0.0
+# tenacity provides the jittered exponential-backoff retry wrapper around each
+# per-item import/export.
+tenacity==9.0.0

--- a/scripts/build-catalog.py
+++ b/scripts/build-catalog.py
@@ -90,6 +90,7 @@ ALLOWED_TAGS = {
     "google-sheets",
     # data movement patterns
     "ingest",
+    "export",
     "migrate",
 }
 ALLOWED_KEYS = {

--- a/scripts/build-catalog.py
+++ b/scripts/build-catalog.py
@@ -86,6 +86,8 @@ ALLOWED_TAGS = {
     "sqlite",
     "snowflake",
     "bigquery",
+    # SaaS / external data sources
+    "google-sheets",
     # data movement patterns
     "ingest",
     "migrate",


### PR DESCRIPTION
## What

Adds a new `flight-plans/flight-google-sheets` template: a reusable, single-file MotherDuck Flight that syncs data **both ways** between Google Sheets and MotherDuck via the DuckDB `gsheets` community extension.

Also adds a new export tag since this can also be used for reverse-ETL. 

- **Import**: a configurable list of sheets, each landing as a MotherDuck table (`CREATE OR REPLACE TABLE ... AS SELECT * FROM read_gsheet(...)` — atomic, idempotent).
- **Export (reverse ETL)**: a configurable list of `SELECT`s, each result published back to a Google Sheet tab (`COPY ... (FORMAT gsheet, OVERWRITE_SHEET TRUE)`) to enable business process automation.
- Use it import-only, export-only, or both (leave the unused list blank).

Engineering properties: full-refresh/idempotent both directions, per-item retries with jittered exponential backoff, per-item failure isolation, an audit log in `<TARGET_DATABASE>.main.gsheets_sync_log`, and **in-memory-only credential handling** (the service-account key is registered inline with the extension, never written to disk).

## Files

- `flight-plans/flight-google-sheets/flight.py` — the Flight source
- `flight-plans/flight-google-sheets/README.md` — catalog entry (front matter + human/agent docs)
- `flight-plans/flight-google-sheets/requirements.txt` — `duckdb`, `pyarrow`, `tenacity`
- `scripts/build-catalog.py` — adds the `google-sheets` tag to `ALLOWED_TAGS`

## Validation

- Catalog front matter validates (`uv run scripts/build-catalog.py` → 31 items) and catalog tests pass.
- The flight's own test suite (unit + integration + end-to-end roundtrip, idempotency, and per-item failure isolation) was run against this exact `flight.py` and passes; the E2E tests exercise it against MotherDuck and live Google Sheets.

> Note: the README's introduction is a first pass and may be refined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)