### PR TITLE
Add prompt and published_date to cookbook recipe front matter

### DIFF
--- a/.agents/skills/motherduck-cookbook/SKILL.md
+++ b/.agents/skills/motherduck-cookbook/SKILL.md
@@ -59,7 +59,7 @@ sync, GitHub Pages, or committed generated JSON.
 ## README Metadata
 
 Catalog READMEs start with YAML front matter. For catalog entries, keep exactly
-these seven keys:
+these nine keys:
 
 ```yaml
 ---
@@ -72,6 +72,13 @@ type: example
 category: ingestion
 features: []
 tags: [dbt]
+prompt: >-
+  I want to build dbt models directly on Parquet/CSV in S3 without copying the
+  data first, running locally against DuckDB or in the cloud against MotherDuck.
+  Help me adapt the "Build Hacker News Models From S3 With dbt" recipe to my own
+  data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-ingestion-s3
+published_date: 2024-12-11
 ---
 ```
 
@@ -98,6 +105,14 @@ Rules:
   (`cloudflare-workers` when `cloudflare` exists), or anything already expressed
   as a feature (`pg_duckdb`, `ducklake`). Tags may be empty. Add a new tag to the
   list only for a significant new third-party thing.
+- `prompt` is a first-person, copy-paste prompt that tells an agent to use the
+  recipe as a guide and adapt it to the user's own data and use case. Lead with
+  the user's goal (drawn from the description), name the recipe by its exact
+  title, keep the "use it as a guide / adapt it to my own data and use case"
+  message, and end with its docs URL `https://motherduck.com/docs/cookbook/<id>`.
+- `published_date` is the recipe's publish date as `YYYY-MM-DD`; downstream
+  surfaces order by it. Use the date the recipe first landed in the repo. The
+  builder also accepts an unquoted YAML date and normalizes it.
 - `flight-plans/` is only for reusable Flight templates: items there must be
   `type: template` and include `flights`. Concrete examples never live there.
 - Examples at the repo root may include `flights` when they can deploy as a

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ injects it as `MOTHERDUCK_TOKEN`.
 
 ## Anatomy of an example
 
-Every example README starts with YAML front matter holding exactly seven keys:
+Every example README starts with YAML front matter holding exactly nine keys:
 
 ```yaml
 ---
@@ -97,6 +97,13 @@ type: example                   # example | template
 category: ingestion             # one primary navigation category (see list below)
 features: []                    # MotherDuck capabilities used; [] if none (see list below)
 tags: [dbt]                     # curated lowercase slugs: significant third-party tools
+prompt: >-                      # first-person, copy-paste prompt to adapt the recipe
+  I want to build dbt models directly on Parquet/CSV in S3 without copying the
+  data first, running locally against DuckDB or in the cloud against MotherDuck.
+  Help me adapt the "Build Hacker News Models From S3 With dbt" recipe to my own
+  data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-ingestion-s3
+published_date: 2024-12-11      # publish date (YYYY-MM-DD); downstream orders by it
 ---
 ```
 
@@ -115,6 +122,12 @@ tags: [dbt]                     # curated lowercase slugs: significant third-par
   `node-postgres`). They are not for datasets, generic concepts (`sql`, `etl`),
   the DuckDB engine, redundant variants, or things already covered by `features`.
   Tags may be empty. Add a new tag only for a significant new tool.
+- `prompt` is a first-person, copy-paste prompt that points an agent at the
+  recipe. Lead with the user's goal, name the recipe by title, keep the "use it
+  as a guide / adapt it to my own data and use case" message, and end with the
+  recipe's docs URL (`https://motherduck.com/docs/cookbook/<id>`).
+- `published_date` is the publish date as `YYYY-MM-DD`, so downstream surfaces
+  can order recipes by recency.
 
 The body follows a consistent, skimmable structure:
 

--- a/catalog.schema.json
+++ b/catalog.schema.json
@@ -64,9 +64,11 @@
         "type",
         "title",
         "description",
+        "prompt",
         "category",
         "features",
         "tags",
+        "published_date",
         "path",
         "urls"
       ],
@@ -85,6 +87,10 @@
           "minLength": 1
         },
         "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prompt": {
           "type": "string",
           "minLength": 1
         },
@@ -121,6 +127,10 @@
             "$ref": "#/$defs/slug"
           },
           "uniqueItems": true
+        },
+        "published_date": {
+          "type": "string",
+          "format": "date"
         },
         "path": {
           "$ref": "#/$defs/path"

--- a/cloudflare-workers-duckoffee/README.md
+++ b/cloudflare-workers-duckoffee/README.md
@@ -11,6 +11,13 @@ type: example
 category: end-to-end
 features: [pg_endpoint, shares]
 tags: [cloudflare, durable-objects, node-postgres, d3, typescript]
+prompt: >-
+  I want to build a full-stack Cloudflare Workers app that reads analytics from a
+  MotherDuck share over the Postgres endpoint and keeps a piece of real-time state (like
+  live votes) at the edge, with a D3 frontend. Help me adapt the "Cloudflare Workers Map
+  and Live Vote on MotherDuck" recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/cloudflare-workers-duckoffee
+published_date: 2026-04-20
 ---
 
 # Cloudflare Workers Map and Live Vote on MotherDuck

--- a/cloudflare-workers/README.md
+++ b/cloudflare-workers/README.md
@@ -10,6 +10,13 @@ type: example
 category: integrations
 features: [pg_endpoint]
 tags: [cloudflare, typescript, node-postgres]
+prompt: >-
+  I want a serverless HTTP API on Cloudflare Workers that queries MotherDuck over the
+  Postgres wire protocol with node-postgres, no DuckDB binary required, and returns
+  JSON. Help me adapt the "Query MotherDuck from Cloudflare Workers" recipe to my own
+  data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/cloudflare-workers
+published_date: 2026-02-18
 ---
 
 # Query MotherDuck from Cloudflare Workers

--- a/dbt-ai-prompt/README.md
+++ b/dbt-ai-prompt/README.md
@@ -11,6 +11,13 @@ type: example
 category: analytics
 features: [shares]
 tags: [dbt]
+prompt: >-
+  I have unstructured text I want to turn into typed columns with an LLM, run entirely
+  as a SQL transformation in dbt with no external API code. Help me adapt the "Extract
+  Structured Data From Reviews With dbt And prompt()" MotherDuck recipe to my own data
+  and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-ai-prompt
+published_date: 2024-12-11
 ---
 
 # Extract Structured Data From Reviews With dbt And prompt()

--- a/dbt-churn-prediction/README.md
+++ b/dbt-churn-prediction/README.md
@@ -10,6 +10,13 @@ type: example
 category: analytics
 features: []
 tags: [dbt, python, scikit-learn]
+prompt: >-
+  I want a SQL-first churn feature pipeline on MotherDuck, building feature and label
+  tables with dbt and keeping model training as a separate Python step. Help me adapt
+  the "Build Churn Prediction Features with dbt" recipe to my own data and use case,
+  using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-churn-prediction
+published_date: 2026-04-16
 ---
 
 # Build Churn Prediction Features with dbt

--- a/dbt-dual-execution/README.md
+++ b/dbt-dual-execution/README.md
@@ -11,6 +11,13 @@ type: example
 category: analytics
 features: []
 tags: [dbt]
+prompt: >-
+  I want to develop dbt models locally against a DuckDB file while still reading from
+  and writing to MotherDuck in the same project, choosing per model whether it lands in
+  the cloud or on disk. Help me adapt the "dbt Dual Execution Across Local DuckDB and
+  MotherDuck" recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-dual-execution
+published_date: 2024-12-20
 ---
 
 # dbt Dual Execution Across Local DuckDB and MotherDuck

--- a/dbt-duckdb-dwh-starter/README.md
+++ b/dbt-duckdb-dwh-starter/README.md
@@ -10,6 +10,12 @@ type: example
 category: analytics
 features: [dives, shares]
 tags: [dbt]
+prompt: >-
+  I want to build a MotherDuck warehouse from scratch with dbt-duckdb and then ship a
+  Dive on top of the mart tables. Help me adapt the "Build a MotherDuck Warehouse with
+  dbt and Deploy a Dive" recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-duckdb-dwh-starter
+published_date: 2026-06-01
 ---
 
 # Build a MotherDuck Warehouse with dbt and Deploy a Dive

--- a/dbt-ducklake/README.md
+++ b/dbt-ducklake/README.md
@@ -10,6 +10,12 @@ type: example
 category: analytics
 features: [ducklake]
 tags: [dbt]
+prompt: >-
+  I want a dbt project that lands raw tables in DuckLake storage and writes analytics
+  models to native MotherDuck. Help me adapt the "Run TPC-DS Models on DuckLake with
+  dbt" recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-ducklake
+published_date: 2024-12-20
 ---
 
 # Run TPC-DS Models on DuckLake with dbt

--- a/dbt-ingestion-s3/README.md
+++ b/dbt-ingestion-s3/README.md
@@ -10,6 +10,13 @@ type: example
 category: ingestion
 features: []
 tags: [dbt]
+prompt: >-
+  I want to build dbt models directly on Parquet/CSV in S3 without copying the data
+  first, running locally against DuckDB or in the cloud against MotherDuck. Help me
+  adapt the "Build Hacker News Models From S3 With dbt" recipe to my own data and use
+  case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-ingestion-s3
+published_date: 2024-12-11
 ---
 
 # Build Hacker News Models From S3 With dbt

--- a/dbt-local-ducklake/README.md
+++ b/dbt-local-ducklake/README.md
@@ -11,6 +11,13 @@ type: example
 category: analytics
 features: [ducklake]
 tags: [dbt, postgres, sqlite]
+prompt: >-
+  I want a lakehouse-style DuckLake catalog (table versioning, snapshots, file
+  compaction) for local dbt development that mirrors a managed DuckLake on MotherDuck.
+  Help me adapt the "Run dbt on a Local DuckLake Catalog" recipe to my own data and use
+  case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-local-ducklake
+published_date: 2024-12-20
 ---
 
 # Run dbt on a Local DuckLake Catalog

--- a/dbt-metricflow/README.md
+++ b/dbt-metricflow/README.md
@@ -10,6 +10,13 @@ type: example
 category: analytics
 features: []
 tags: [dbt, metricflow]
+prompt: >-
+  I want to define metrics once with dbt MetricFlow over a fact table and query them
+  identically on a local DuckDB file and on MotherDuck. Help me adapt the "Define and
+  Query Metrics with dbt MetricFlow on MotherDuck" recipe to my own data and use case,
+  using it as a guide:
+  https://motherduck.com/docs/cookbook/dbt-metricflow
+published_date: 2025-10-20
 ---
 
 # Define and Query Metrics with dbt MetricFlow on MotherDuck

--- a/dlt-db-replication/README.md
+++ b/dlt-db-replication/README.md
@@ -10,6 +10,13 @@ type: example
 category: ingestion
 features: []
 tags: [dlt, postgres, connectorx]
+prompt: >-
+  I need to copy and refresh tables from a PostgreSQL database into MotherDuck with a
+  dlt pipeline, with tunable extract, normalize, and load parallelism. Help me adapt the
+  "Replicate PostgreSQL Tables to MotherDuck with dlt" recipe to my own data and use
+  case, using it as a guide:
+  https://motherduck.com/docs/cookbook/dlt-db-replication
+published_date: 2024-12-11
 ---
 
 # Replicate PostgreSQL Tables to MotherDuck with dlt

--- a/flight-plans/flight-bigquery-ingest/README.md
+++ b/flight-plans/flight-bigquery-ingest/README.md
@@ -13,6 +13,13 @@ type: template
 category: ingestion
 features: [flights]
 tags: [bigquery, ingest, migrate]
+prompt: >-
+  I want scheduled, incremental ingestion from BigQuery into MotherDuck using a
+  date-partition watermark with idempotent per-partition DELETE plus INSERT, as part of
+  moving off BigQuery. Help me adapt the "Incrementally Ingest BigQuery into MotherDuck"
+  Flight recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-bigquery-ingest
+published_date: 2026-06-09
 ---
 
 # Incrementally Ingest BigQuery into MotherDuck

--- a/flight-plans/flight-dive-usage-metrics/README.md
+++ b/flight-plans/flight-dive-usage-metrics/README.md
@@ -12,6 +12,13 @@ type: template
 category: analytics
 features: [flights, dives]
 tags: []
+prompt: >-
+  I want a scheduled, trend-aware map of which data objects my organization's Dives
+  reference and how they connect, mined from the SQL embedded in each Dive. Help me
+  adapt the "Map Data Usage and Relationships Across Dives" Flight recipe to my own data
+  and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-dive-usage-metrics
+published_date: 2026-06-09
 ---
 
 # Map Data Usage and Relationships Across Dives

--- a/flight-plans/flight-dlt-ingest/README.md
+++ b/flight-plans/flight-dlt-ingest/README.md
@@ -10,6 +10,13 @@ type: template
 category: ingestion
 features: [flights]
 tags: [dlt, ingest]
+prompt: >-
+  I want Python ingestion that runs on a schedule as a Flight and handles API calls,
+  schema drift, state, and merge behavior with dlt instead of hand-writing every INSERT.
+  Help me adapt the "Run a dlt Ingest Pipeline as a Flight" recipe to my own data and
+  use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-dlt-ingest
+published_date: 2026-06-08
 ---
 
 # Run a dlt Ingest Pipeline as a Flight

--- a/flight-plans/flight-ducklake-maintenance/README.md
+++ b/flight-plans/flight-ducklake-maintenance/README.md
@@ -11,6 +11,13 @@ type: template
 category: automation
 features: [flights, ducklake]
 tags: []
+prompt: >-
+  My DuckLake is accumulating small files, deleted rows, and stale snapshots, and I want
+  scheduled compaction and cleanup tuned to my ingest pattern. Help me adapt the "Keep
+  DuckLake Reads Fast With Scheduled Maintenance" Flight recipe to my own data and use
+  case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-ducklake-maintenance
+published_date: 2026-06-15
 ---
 
 # Keep DuckLake Reads Fast With Scheduled Maintenance

--- a/flight-plans/flight-freshness-alert/README.md
+++ b/flight-plans/flight-freshness-alert/README.md
@@ -10,6 +10,13 @@ type: template
 category: automation
 features: [flights]
 tags: [slack]
+prompt: >-
+  I want scheduled freshness monitoring on my MotherDuck tables with dbt-style
+  warn/error age thresholds and a Slack alert when data goes stale. Help me adapt the
+  "Alert on Stale Tables From a Flight" recipe to my own data and use case, using it as
+  a guide:
+  https://motherduck.com/docs/cookbook/flight-freshness-alert
+published_date: 2026-06-08
 ---
 
 # Alert on Stale Tables From a Flight

--- a/flight-plans/flight-google-sheets/README.md
+++ b/flight-plans/flight-google-sheets/README.md
@@ -12,6 +12,13 @@ type: template
 category: ingestion
 features: [flights]
 tags: [google-sheets, ingest, export]
+prompt: >-
+  I want to sync data both ways between Google Sheets and MotherDuck on a schedule,
+  importing sheets into tables and exporting query results back to sheet tabs as reverse
+  ETL. Help me adapt the "Sync Google Sheets and MotherDuck With a Flight" recipe to my
+  own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-google-sheets
+published_date: 2026-06-15
 ---
 
 # Sync Google Sheets and MotherDuck With a Flight

--- a/flight-plans/flight-postgres-ingest/README.md
+++ b/flight-plans/flight-postgres-ingest/README.md
@@ -11,6 +11,13 @@ type: template
 category: ingestion
 features: [flights]
 tags: [postgres, ingest, migrate]
+prompt: >-
+  I want a config-driven, re-runnable Flight that mirrors selected PostgreSQL tables
+  into MotherDuck with one streaming full-refresh per table, retries, and an audit log.
+  Help me adapt the "Mirror PostgreSQL Tables into MotherDuck With a Flight" recipe to
+  my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-postgres-ingest
+published_date: 2026-06-09
 ---
 
 # Mirror PostgreSQL Tables into MotherDuck With a Flight

--- a/flight-plans/flight-provision-user-databases/README.md
+++ b/flight-plans/flight-provision-user-databases/README.md
@@ -10,6 +10,13 @@ type: template
 category: automation
 features: [flights, shares]
 tags: []
+prompt: >-
+  My application gives each user their own isolated MotherDuck database and share, and I
+  want an admin Flight that provisions them from a control table and revokes access when
+  a user goes inactive. Help me adapt the "Provision User Databases and Shares" recipe
+  to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-provision-user-databases
+published_date: 2026-06-08
 ---
 
 # Provision User Databases and Shares

--- a/flight-plans/flight-scheduled-s3-ingest/README.md
+++ b/flight-plans/flight-scheduled-s3-ingest/README.md
@@ -10,6 +10,13 @@ type: template
 category: ingestion
 features: [flights]
 tags: [ingest, s3]
+prompt: >-
+  My data already lands as Hive-partitioned Parquet in S3, and I want a scheduled Flight
+  that incrementally refreshes a MotherDuck table by reading only the partition that
+  changes. Help me adapt the "Ingest Partitioned S3 Parquet on a Schedule" recipe to my
+  own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-scheduled-s3-ingest
+published_date: 2026-06-08
 ---
 
 # Ingest Partitioned S3 Parquet on a Schedule

--- a/flight-plans/flight-snowflake-ingest/README.md
+++ b/flight-plans/flight-snowflake-ingest/README.md
@@ -11,6 +11,14 @@ type: template
 category: ingestion
 features: [flights]
 tags: [snowflake, ingest, migrate]
+prompt: >-
+  I want a code-driven, re-runnable Flight that ingests Snowflake tables into MotherDuck
+  in two phases (discover an editable inventory, then move the selected tables via
+  Arrow), as part of migrating off Snowflake. Help me adapt the "Ingest Snowflake Tables
+  into MotherDuck From a Flight" recipe to my own data and use case, using it as a
+  guide:
+  https://motherduck.com/docs/cookbook/flight-snowflake-ingest
+published_date: 2026-06-09
 ---
 
 # Ingest Snowflake Tables into MotherDuck From a Flight

--- a/flight-plans/flight-sql-transformation/README.md
+++ b/flight-plans/flight-sql-transformation/README.md
@@ -11,6 +11,13 @@ type: template
 category: analytics
 features: [flights]
 tags: []
+prompt: >-
+  I have a set of CREATE TABLE AS / VIEW / MACRO statements I want to run in dependency
+  order as a DAG inside one Flight, with independent statements running concurrently and
+  automatic retries. Help me adapt the "Run SQL Transformations in Order" recipe to my
+  own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/flight-sql-transformation
+published_date: 2026-06-15
 ---
 
 # Run SQL Transformations in Order and in Parallel

--- a/motherduck-grafana/README.md
+++ b/motherduck-grafana/README.md
@@ -10,6 +10,12 @@ type: example
 category: integrations
 features: []
 tags: [grafana, docker]
+prompt: >-
+  I want to build Grafana dashboards and time-series panels on top of MotherDuck data,
+  with the DuckDB datasource plugin wired up. Help me adapt the "Visualize MotherDuck
+  Data in Grafana" recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/motherduck-grafana
+published_date: 2025-09-08
 ---
 
 # Visualize MotherDuck Data in Grafana

--- a/motherduck-ui/README.md
+++ b/motherduck-ui/README.md
@@ -10,6 +10,13 @@ type: example
 category: getting-started
 features: []
 tags: []
+prompt: >-
+  I want a hands-on, query-by-query walkthrough for loading a CSV, profiling it with
+  SUMMARIZE, cleaning messy columns, and answering an analysis question in the
+  MotherDuck web UI. Help me adapt the "Clean and Analyze a CSV in the MotherDuck UI"
+  recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/motherduck-ui
+published_date: 2025-01-29
 ---
 
 # Clean and Analyze a CSV in the MotherDuck UI

--- a/nba-box-scores/README.md
+++ b/nba-box-scores/README.md
@@ -11,6 +11,13 @@ type: example
 category: end-to-end
 features: [flights, dives]
 tags: [python, typescript]
+prompt: >-
+  I want to pair a scheduled Python Flight ingest with a Dive frontend that reads the
+  data live, all deployed as code on MotherDuck. Help me adapt the "NBA Box Scores on
+  MotherDuck Flights and a Dive" recipe to my own data and use case, using it as a
+  guide:
+  https://motherduck.com/docs/cookbook/nba-box-scores
+published_date: 2026-06-09
 ---
 
 # NBA Box Scores on MotherDuck Flights and a Dive

--- a/nodejs-motherduck/README.md
+++ b/nodejs-motherduck/README.md
@@ -11,6 +11,13 @@ type: example
 category: getting-started
 features: []
 tags: [nodejs, javascript, generic-pool]
+prompt: >-
+  I want to run DuckDB SQL against MotherDuck from a Node.js service using the native
+  DuckDB Neo driver, including a connection pool for concurrent workloads. Help me adapt
+  the "Connect to MotherDuck from Node.js with the DuckDB Neo Driver" recipe to my own
+  data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/nodejs-motherduck
+published_date: 2026-02-04
 ---
 
 # Connect to MotherDuck from Node.js with the DuckDB Neo Driver

--- a/postgres-demo/README.md
+++ b/postgres-demo/README.md
@@ -10,6 +10,13 @@ type: example
 category: integrations
 features: [pg_duckdb]
 tags: [postgres, docker]
+prompt: >-
+  I want a hybrid setup where local Postgres and MotherDuck can read each other through
+  pg_duckdb, scanning Postgres from DuckDB and querying MotherDuck from psql. Help me
+  adapt the "Bridge Local Postgres and MotherDuck with pg_duckdb" recipe to my own data
+  and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/postgres-demo
+published_date: 2025-01-30
 ---
 
 # Bridge Local Postgres and MotherDuck with pg_duckdb

--- a/python-ingestion/README.md
+++ b/python-ingestion/README.md
@@ -10,6 +10,13 @@ type: example
 category: ingestion
 features: []
 tags: [python, pyarrow, pandas]
+prompt: >-
+  I need a standalone Python script that pulls JSON from an HTTP API (or an in-memory
+  dataframe) and loads it into a MotherDuck table, with both a pandas path and a typed
+  PyArrow path. Help me adapt the "Ingest API Data into MotherDuck with Python" recipe
+  to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/python-ingestion
+published_date: 2025-01-30
 ---
 
 # Ingest API Data into MotherDuck with Python

--- a/scripts/build-catalog.py
+++ b/scripts/build-catalog.py
@@ -5,10 +5,11 @@
 
 """Validate README front matter and build the examples catalog.
 
-Every catalog entry is a README.md with YAML front matter holding exactly seven
-keys: title, id, description, type, category, features, tags. Running this script
-with no output path validates the front matter across the repo (non-zero exit on
-the first problem). Pass --output to also write catalog.json.
+Every catalog entry is a README.md with YAML front matter holding exactly nine
+keys: title, id, description, type, category, features, tags, prompt,
+published_date. Running this script with no output path validates the front
+matter across the repo (non-zero exit on the first problem). Pass --output to
+also write catalog.json.
 """
 
 from __future__ import annotations
@@ -16,7 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -97,12 +98,22 @@ ALLOWED_KEYS = {
     "title",
     "id",
     "description",
+    "prompt",
     "type",
     "category",
     "features",
     "tags",
+    "published_date",
 }
-REQUIRED_KEYS = {"title", "id", "description", "type", "category"}
+REQUIRED_KEYS = {
+    "title",
+    "id",
+    "description",
+    "prompt",
+    "type",
+    "category",
+    "published_date",
+}
 FLIGHT_PLANS_DIR = "flight-plans"
 
 SKIPPED_DIR_NAMES = {
@@ -186,6 +197,28 @@ def assert_slug_list(data: dict[str, Any], readme_path: Path, key: str) -> list[
     return cleaned
 
 
+def assert_date(data: dict[str, Any], readme_path: Path, key: str) -> str:
+    """Return a YYYY-MM-DD string from a YAML date/datetime or ISO date string.
+
+    PyYAML parses an unquoted ISO date in front matter as a datetime.date, so
+    accept that as well as a quoted string and normalize both to a plain
+    YYYY-MM-DD string.
+    """
+    value = data.get(key)
+    if isinstance(value, datetime):
+        value = value.date()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str) and value.strip():
+        try:
+            return date.fromisoformat(value.strip()).isoformat()
+        except ValueError as error:
+            raise CatalogError(
+                f"{readme_path}: {key} must be a YYYY-MM-DD date, got {value.strip()!r}"
+            ) from error
+    raise CatalogError(f"{readme_path}: {key} must be a YYYY-MM-DD date string")
+
+
 def build_item(
     repo_root: Path, readme_path: Path, frontmatter: dict[str, Any], repo: str, ref: str
 ) -> dict[str, Any] | None:
@@ -239,6 +272,9 @@ def build_item(
             f"for a significant new tool. Allowed tags: {sorted(ALLOWED_TAGS)}"
         )
 
+    prompt = assert_string(frontmatter, readme_path, "prompt")
+    published_date = assert_date(frontmatter, readme_path, "published_date")
+
     relative_dir = readme_path.parent.relative_to(repo_root).as_posix()
     under_flight_plans = relative_dir == FLIGHT_PLANS_DIR or relative_dir.startswith(
         f"{FLIGHT_PLANS_DIR}/"
@@ -262,9 +298,11 @@ def build_item(
         "type": item_type,
         "title": assert_string(frontmatter, readme_path, "title"),
         "description": assert_string(frontmatter, readme_path, "description"),
+        "prompt": prompt,
         "category": category,
         "features": features,
         "tags": tags,
+        "published_date": published_date,
         "path": relative_dir,
         "urls": build_urls(repo=repo, ref=ref, path=relative_dir),
     }

--- a/sqlmesh-demo/README.md
+++ b/sqlmesh-demo/README.md
@@ -10,6 +10,13 @@ type: example
 category: analytics
 features: []
 tags: [sqlmesh, dlt]
+prompt: >-
+  I want a SQLMesh project on MotherDuck that transforms data through interim,
+  conformed, and mart layers (incremental models, SCD type 2, audits, virtual
+  environments), fed by a dlt ingest. Help me adapt the "Transform Stock Data with
+  SQLMesh on MotherDuck" recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/sqlmesh-demo
+published_date: 2025-01-14
 ---
 
 # Transform Stock Data with SQLMesh on MotherDuck

--- a/statsbomb-360-football-matches/README.md
+++ b/statsbomb-360-football-matches/README.md
@@ -12,6 +12,14 @@ type: example
 category: end-to-end
 features: [flights, dives]
 tags: [python, typescript, d3]
+prompt: >-
+  I want a multi-stage Flight pipeline (raw to core to marts, transformed with
+  in-warehouse SQL) paired with a bespoke D3 Dive that renders the data live, all
+  deployed as code on MotherDuck. Help me adapt the "StatsBomb 360 Football Matches —
+  Flights pipeline + animated Dive" recipe to my own data and use case, using it as a
+  guide:
+  https://motherduck.com/docs/cookbook/statsbomb-360-football-matches
+published_date: 2026-06-15
 ---
 
 # StatsBomb 360 Football Matches — Flights pipeline + animated Dive

--- a/tests/test_build_catalog.py
+++ b/tests/test_build_catalog.py
@@ -36,6 +36,8 @@ features: []
 tags:
   - python
   - pyarrow
+prompt: Adapt this Python API ingestion recipe to my own data and use case.
+published_date: 2025-03-14
 """,
     )
     write_readme(
@@ -70,9 +72,11 @@ type: example
             "type": "example",
             "title": "Ingest API data into MotherDuck with Python",
             "description": "Load API data into MotherDuck from Python.",
+            "prompt": "Adapt this Python API ingestion recipe to my own data and use case.",
             "category": "ingestion",
             "features": [],
             "tags": ["python", "pyarrow"],
+            "published_date": "2025-03-14",
             "path": "python-ingestion",
             "urls": {
                 "github": "https://github.com/motherduckdb/motherduck-cookbook/tree/main/python-ingestion",
@@ -111,6 +115,8 @@ id: duplicate
 description: Duplicate IDs should not be allowed.
 type: example
 category: integrations
+prompt: Adapt this recipe to my own data and use case.
+published_date: 2025-01-01
 """,
         )
 
@@ -157,6 +163,8 @@ features:
   - flights
 tags:
   - dbt
+prompt: Adapt this dbt-on-S3 recipe to my own data and use case.
+published_date: 2025-02-02
 """,
     )
 
@@ -179,6 +187,8 @@ features:
   - flights
 tags:
   - dbt
+prompt: Adapt this recipe to my own data and use case.
+published_date: 2025-02-02
 """,
     )
 
@@ -203,6 +213,8 @@ features:
   - flights
 tags:
   - dbt
+prompt: Adapt this dbt Flight recipe to my own data and use case.
+published_date: 2025-02-02
 """,
     )
 
@@ -226,6 +238,8 @@ description: Load API data into MotherDuck from Python.
 type: example
 features: []
 tags: [python]
+prompt: Adapt this recipe to my own data and use case.
+published_date: 2025-01-01
 """,
     )
 
@@ -247,10 +261,89 @@ type: example
 category: etl
 features: []
 tags: [python]
+prompt: Adapt this recipe to my own data and use case.
+published_date: 2025-01-01
 """,
     )
 
     with pytest.raises(
         build_catalog_module.CatalogError, match="category must be one of"
+    ):
+        build_catalog_module.build_catalog(repo_root)
+
+
+def test_missing_prompt_fails(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    write_readme(
+        repo_root / "a-recipe" / "README.md",
+        """
+title: A recipe
+id: a-recipe
+description: A recipe without a prompt.
+type: example
+category: ingestion
+published_date: 2025-07-09
+""",
+    )
+
+    with pytest.raises(
+        build_catalog_module.CatalogError, match="missing required keys .*prompt"
+    ):
+        build_catalog_module.build_catalog(repo_root)
+
+
+def test_published_date_normalizes_yaml_date_and_string(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    # An unquoted ISO date is parsed by PyYAML as a datetime.date.
+    write_readme(
+        repo_root / "a-recipe" / "README.md",
+        """
+title: A recipe
+id: a-recipe
+description: Publish date written as an unquoted YAML date.
+type: example
+category: ingestion
+prompt: Adapt this recipe to my own data and use case.
+published_date: 2025-07-09
+""",
+    )
+    # A quoted date is parsed as a string.
+    write_readme(
+        repo_root / "b-recipe" / "README.md",
+        '''
+title: B recipe
+id: b-recipe
+description: Publish date written as a quoted string.
+type: example
+category: ingestion
+prompt: Adapt this recipe to my own data and use case.
+published_date: "2025-07-10"
+''',
+    )
+
+    catalog = build_catalog_module.build_catalog(repo_root)
+    dates = {item["id"]: item["published_date"] for item in catalog["items"]}
+
+    assert dates == {"a-recipe": "2025-07-09", "b-recipe": "2025-07-10"}
+    assert all(isinstance(item["published_date"], str) for item in catalog["items"])
+
+
+def test_invalid_published_date_fails(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    write_readme(
+        repo_root / "a-recipe" / "README.md",
+        """
+title: A recipe
+id: a-recipe
+description: Publish date that is not a valid ISO date.
+type: example
+category: ingestion
+prompt: Adapt this recipe to my own data and use case.
+published_date: not-a-date
+""",
+    )
+
+    with pytest.raises(
+        build_catalog_module.CatalogError, match="must be a YYYY-MM-DD date"
     ):
         build_catalog_module.build_catalog(repo_root)

--- a/vercel-agent-analytics/README.md
+++ b/vercel-agent-analytics/README.md
@@ -11,6 +11,13 @@ type: example
 category: end-to-end
 features: []
 tags: [vercel, nodejs, typescript]
+prompt: >-
+  I want to capture my Vercel log drain, classify AI bot, agent, and AI-referred human
+  traffic from the user agent and referer, and write it into MotherDuck to query live,
+  with no AWS or S3. Help me adapt the "Capture Vercel Log Drain Traffic and Classify AI
+  Agents in MotherDuck" recipe to my own data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/vercel-agent-analytics
+published_date: 2026-04-24
 ---
 
 # Capture Vercel Log Drain Traffic and Classify AI Agents in MotherDuck

--- a/vercel-nextjs/README.md
+++ b/vercel-nextjs/README.md
@@ -10,6 +10,13 @@ type: example
 category: integrations
 features: [pg_endpoint]
 tags: [vercel, nextjs, node-postgres]
+prompt: >-
+  I'm building a Vercel/Next.js backend that reads MotherDuck data through Next.js API
+  routes over the Postgres wire protocol with pooled, parameterized SQL and no DuckDB
+  binary. Help me adapt the "Query MotherDuck from Vercel and Next.js" recipe to my own
+  data and use case, using it as a guide:
+  https://motherduck.com/docs/cookbook/vercel-nextjs
+published_date: 2026-03-31
 ---
 
 # Query MotherDuck from Vercel and Next.js


### PR DESCRIPTION
Adds two required front-matter keys to all 32 catalog recipes: a first-person `prompt` that points an agent at the recipe (lead with the user's goal, name the recipe, keep the "use it as a guide / adapt it to my own data and use case" message, and link the docs URL) and a `published_date` so downstream surfaces can order recipes by recency. Surfaces both in the generated catalog via `scripts/build-catalog.py` (with a date-normalizing helper that accepts an unquoted YAML date or a `YYYY-MM-DD` string) and `catalog.schema.json`, both now required. Updates the root `README.md` and the `motherduck-cookbook` skill doc to document the nine-key front matter, and extends the catalog tests (missing prompt, date normalization, invalid date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
