### PR TITLE
Add flight-hubspot-list-sync Flight Plan

### DIFF
--- a/flight-plans/flight-hubspot-list-sync/README.md
+++ b/flight-plans/flight-hubspot-list-sync/README.md
@@ -12,6 +12,14 @@ type: template
 category: integrations
 features: [flights]
 tags: [hubspot]
+prompt: >-
+  I want a Flight that runs a MotherDuck SQL query to produce a list of emails and
+  reconciles a HubSpot static contact list to match it (data activation / reverse
+  ETL) — resolving emails to contact IDs, applying the minimal add/remove, with
+  retries and an audit log. Help me adapt the "Update a HubSpot List From a
+  MotherDuck Query With a Flight" recipe to my own data and use case, using it as a
+  guide: https://motherduck.com/docs/cookbook/flight-hubspot-list-sync
+published_date: 2026-06-17
 ---
 
 # Sync a HubSpot List From a MotherDuck Query With a Flight

--- a/flight-plans/flight-hubspot-list-sync/README.md
+++ b/flight-plans/flight-hubspot-list-sync/README.md
@@ -1,13 +1,13 @@
 ---
-title: Sync a HubSpot List From a MotherDuck Query With a Flight
+title: Update a HubSpot List From a MotherDuck Query With a Flight
 id: flight-hubspot-list-sync
 description: >-
-  A reusable Flight that reconciles a HubSpot static contact list to the result
-  of a parameterized MotherDuck query: resolves emails to contact IDs, diffs
-  against the list's current members, and applies the minimal add/remove via the
+  An example of data activation / reverse ETL with Flights.
+  Run a MotherDuck SQL Query to pull a list of emails and update a Hubspot list.
+  That Hubspot list can then be used for automatic customer or marketing activities.
+  This flight resolves emails to Hubspot contact IDs and applies the minimal add/remove via the
   Lists v3 API. Idempotent re-runs, retries with backoff, skip-and-log for
-  unmatched emails, and an audit ledger. Use it to keep a HubSpot audience in
-  sync with a SQL query on a schedule.
+  unmatched emails, and an audit ledger.
 type: template
 category: integrations
 features: [flights]
@@ -16,7 +16,8 @@ tags: [hubspot]
 
 # Sync a HubSpot List From a MotherDuck Query With a Flight
 
-A single-file Flight that drives the membership of a HubSpot **static** contact
+Flights allow you to take action in your business based on MotherDuck data.
+This flight updates the membership of a HubSpot contact
 list from a MotherDuck query. The query returns email addresses; the Flight
 makes the list match that set on every run.
 
@@ -53,12 +54,10 @@ contact are skipped and logged so one bad address never fails the run.
 - Which MotherDuck `QUERY` defines the audience, and does it output an `email`
   column (or set `EMAIL_COLUMN`)?
 - Which **static** HubSpot list receives the membership? Create a dedicated
-  `MANUAL` list so a bad run can't disturb an important one, and use its list ID.
+  `MANUAL` list and use its list ID.
 - Which HubSpot credential and scopes? A Service Key or private app token with
   `crm.lists.read`, `crm.lists.write`, `crm.objects.contacts.read`,
   `crm.objects.contacts.write`.
-- Should unmatched emails stay skipped-and-logged (the default), or do you need
-  missing contacts created first (a code change)?
 - What schedule (cron, UTC) matches how often the underlying data changes?
 
 ## Caveats
@@ -104,7 +103,7 @@ runtime; for a local run you can instead export `HUBSPOT_PRIVATE_APP_TOKEN`.
 ## Run it
 
 You need a MotherDuck account and token, plus a HubSpot token and an existing
-static list. For a safe first pass, use `DRY_RUN=true` to see the diff without
+Hubspot static list. For a safe first pass, use `DRY_RUN=true` to see the diff without
 touching the list.
 
 ```bash
@@ -145,10 +144,6 @@ CREATE SECRET hubspot IN motherduck (
 );
 ```
 
-(`getenv()` is only available in the duckdb CLI; it is not defined in
-MotherDuck's server-side execution, so the UI/Python paths need the literal
-value.)
-
 Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
 checked in; adapt the arguments), passing:
 
@@ -175,9 +170,7 @@ schedule with the user before adding one.
 - **Keep the literal token out of history.** Prefer the duckdb-CLI `getenv()`
   form above (or the Settings UI) so the raw token is not typed into SQL text or
   shell history.
-- **Dedicated static list.** Point the Flight at a purpose-built `MANUAL` list so
-  a misconfigured run cannot disturb a list other systems depend on. The Flight
-  also refuses non-static lists outright.
+- **Dedicated static list.** Point the Flight at a purpose-built `MANUAL` list.
 - **Validated audit target.** `AUDIT_TABLE` is checked as plain SQL identifiers
   before it is interpolated into `CREATE`/`INSERT` (not parameterizable).
 - **Least privilege.** Scope the Service Key / private app token to exactly the

--- a/flight-plans/flight-hubspot-list-sync/README.md
+++ b/flight-plans/flight-hubspot-list-sync/README.md
@@ -1,0 +1,195 @@
+---
+title: Sync a HubSpot List From a MotherDuck Query With a Flight
+id: flight-hubspot-list-sync
+description: >-
+  A reusable Flight that reconciles a HubSpot static contact list to the result
+  of a parameterized MotherDuck query: resolves emails to contact IDs, diffs
+  against the list's current members, and applies the minimal add/remove via the
+  Lists v3 API. Idempotent re-runs, retries with backoff, skip-and-log for
+  unmatched emails, and an audit ledger. Use it to keep a HubSpot audience in
+  sync with a SQL query on a schedule.
+type: template
+category: integrations
+features: [flights]
+tags: [hubspot]
+---
+
+# Sync a HubSpot List From a MotherDuck Query With a Flight
+
+A single-file Flight that drives the membership of a HubSpot **static** contact
+list from a MotherDuck query. The query returns email addresses; the Flight
+makes the list match that set on every run.
+
+The pattern is **reconcile by diff**, not clear-and-re-add. Each run reads the
+list's current members, computes the adds and removes against the query output,
+and applies only the difference. That means the list is never emptied
+mid-run, a re-run with unchanged data is a no-op, and the work (and API calls)
+scale with the change, not the audience size. Emails with no matching HubSpot
+contact are skipped and logged so one bad address never fails the run.
+
+## How it works
+
+`flight.py` runs a fixed sequence:
+
+1. **Connect.** `duckdb.connect("md:")` and run `QUERY`, reading the
+   `EMAIL_COLUMN` column (normalized to lowercase, de-duplicated, blanks dropped).
+2. **Resolve emails to record IDs.** Batch-read contacts by `email` (HubSpot's
+   `POST /crm/v3/objects/contacts/batch/read`, 100 inputs per call). Unmatched
+   emails are collected and logged, not created.
+3. **Guard the target.** Fetch the list and refuse to continue unless its
+   `processingType` is `MANUAL` or `SNAPSHOT` — HubSpot rejects membership
+   writes on `DYNAMIC` (active) lists.
+4. **Diff.** Read current membership (paginated), then compute
+   `to_add = desired − current` and `to_remove = current − desired`.
+5. **Apply.** One or more `PUT /crm/v3/lists/{listId}/memberships/add-and-remove`
+   calls (chunked), each wrapped in a tenacity retry with jittered exponential
+   backoff that honors `429 Retry-After`. `DRY_RUN=true` logs the diff and stops
+   here.
+6. **Audit.** Append one row per run to `AUDIT_TABLE` (counts, status, a hash of
+   the query) for an at-a-glance history.
+
+## Questions to answer
+
+- Which MotherDuck `QUERY` defines the audience, and does it output an `email`
+  column (or set `EMAIL_COLUMN`)?
+- Which **static** HubSpot list receives the membership? Create a dedicated
+  `MANUAL` list so a bad run can't disturb an important one, and use its list ID.
+- Which HubSpot credential and scopes? A Service Key or private app token with
+  `crm.lists.read`, `crm.lists.write`, `crm.objects.contacts.read`,
+  `crm.objects.contacts.write`.
+- Should unmatched emails stay skipped-and-logged (the default), or do you need
+  missing contacts created first (a code change)?
+- What schedule (cron, UTC) matches how often the underlying data changes?
+
+## Caveats
+
+- **Static lists only.** Membership writes work on `MANUAL`/`SNAPSHOT` lists;
+  `DYNAMIC` (active) lists are rule-maintained by HubSpot and the Flight will
+  stop with a clear error if pointed at one.
+- **Unmatched emails are skipped, not created.** An email with no contact record
+  can't be added to a list. The run still succeeds and logs a sample; switch the
+  resolve step to a batch upsert if you want contacts created.
+- **Members are resolved by email.** Duplicate or recently-changed emails depend
+  on HubSpot's indexing; a contact created seconds earlier may not resolve yet.
+- **Rate limits.** The client retries `429`/`5xx` with backoff and honors
+  `Retry-After`, but a very large audience still consumes daily API quota.
+- **`MEMBERSHIP_CHUNK_SIZE` default (1000) is conservative.** Tune it against
+  your account's documented limits if you sync large lists.
+
+## What you'll adjust
+
+No code edits are required. Everything is read from Flight config/env, plus a
+MotherDuck Flights secret named `hubspot` that holds the HubSpot token (a
+credential, so it must be a secret, never config).
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `QUERY` | (required) | MotherDuck SQL whose result drives the list. Must output the email column. |
+| `HUBSPOT_LIST_ID` | (required) | Target static (`MANUAL`/`SNAPSHOT`) list ID to reconcile. |
+| `EMAIL_COLUMN` | `email` | Name of the column in the query result holding emails. |
+| `OBJECT_TYPE_ID` | `0-1` | HubSpot list object type (`0-1` = contacts). |
+| `OBJECT_NAME` | `contacts` | CRM object path used for the batch read. |
+| `ID_PROPERTY` | `email` | Property used to resolve query rows to records. |
+| `BATCH_READ_SIZE` | `100` | Emails per batch-read call (HubSpot caps this at 100). |
+| `MEMBERSHIP_CHUNK_SIZE` | `1000` | Record IDs per membership write call. |
+| `MAX_RETRIES` | `5` | Retry attempts per HTTP operation. |
+| `RETRY_BASE_SECONDS` | `2` | Exponential-backoff multiplier (seconds). |
+| `DRY_RUN` | `false` | `true` computes and logs the diff without changing the list. |
+| `AUDIT_TABLE` | `hubspot_list_sync.main.flight_tracker` | Ledger table (created if absent); `""` to skip. |
+| `hubspot` **secret** | (required) | `TYPE flights` secret with param `ACCESS_TOKEN` (Service Key or private app token). |
+
+The secret injects its param as `HUBSPOT_ACCESS_TOKEN`. The Flight reads that at
+runtime; for a local run you can instead export `HUBSPOT_PRIVATE_APP_TOKEN`.
+
+## Run it
+
+You need a MotherDuck account and token, plus a HubSpot token and an existing
+static list. For a safe first pass, use `DRY_RUN=true` to see the diff without
+touching the list.
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+export HUBSPOT_ACCESS_TOKEN=your_service_key_or_pat   # or HUBSPOT_PRIVATE_APP_TOKEN
+QUERY="SELECT email FROM my_db.main.audience" \
+HUBSPOT_LIST_ID=12345 \
+DRY_RUN=true \
+  uv run --with-requirements requirements.txt flight.py
+```
+
+This runs the query, resolves emails to contact IDs, reads current membership,
+and logs `desired / current / add / remove / unmatched`. Drop `DRY_RUN` (or set
+it to `false`) to apply the diff and write an audit row.
+
+### Deploy as a Flight
+
+First store the HubSpot token as a **Flights secret** named `hubspot` (UI:
+[Settings > Secrets](https://app.motherduck.com/settings/secrets), type
+**Flights**, param `ACCESS_TOKEN`). Or via SQL from a write-enabled connection
+(read-only connections reject `CREATE SECRET`):
+
+```sql
+CREATE SECRET hubspot IN motherduck (
+  TYPE flights,
+  PARAMS MAP { 'ACCESS_TOKEN': 'your_service_key_or_pat' }
+);
+```
+
+To avoid putting the literal token in SQL or shell history, run that statement
+from the **duckdb CLI** with the token in an env var — `getenv()` resolves
+client-side there:
+
+```sql
+CREATE SECRET hubspot IN motherduck (
+  TYPE flights,
+  PARAMS MAP { 'ACCESS_TOKEN': getenv('HUBSPOT_PRIVATE_APP_TOKEN') }
+);
+```
+
+(`getenv()` is only available in the duckdb CLI; it is not defined in
+MotherDuck's server-side execution, so the UI/Python paths need the literal
+value.)
+
+Then create the Flight with the `MD_CREATE_FLIGHT` SQL function (no deploy SQL is
+checked in; adapt the arguments), passing:
+
+- `name`: a Flight name, for example `hubspot-list-sync`
+- `source_code`: [`flight.py`](flight.py)
+- `requirements_txt`: [`requirements.txt`](requirements.txt)
+- `flight_secret_names`: `["hubspot"]` so `HUBSPOT_ACCESS_TOKEN` is injected
+- `config`: at least `QUERY` and `HUBSPOT_LIST_ID`, plus any other knobs above.
+  The token stays in the `hubspot` secret, never in config.
+
+A MotherDuck token is attached to the Flight automatically and injected at run
+time as `MOTHERDUCK_TOKEN`; no token argument is needed.
+
+Create without a schedule, run once with `MD_RUN_FLIGHT(flight_id := ...)` (the
+id is returned by `MD_CREATE_FLIGHT` and listed by `MD_FLIGHTS()`), and confirm
+the list membership matches the query and `AUDIT_TABLE` has a new row. Decide a
+schedule with the user before adding one.
+
+## Security
+
+- **Token in a secret, never config or SQL.** The HubSpot token comes from a
+  `TYPE flights` secret and is read at runtime as `HUBSPOT_ACCESS_TOKEN`. The code
+  only ever places it on the HTTP `Authorization` header — it is never logged.
+- **Keep the literal token out of history.** Prefer the duckdb-CLI `getenv()`
+  form above (or the Settings UI) so the raw token is not typed into SQL text or
+  shell history.
+- **Dedicated static list.** Point the Flight at a purpose-built `MANUAL` list so
+  a misconfigured run cannot disturb a list other systems depend on. The Flight
+  also refuses non-static lists outright.
+- **Validated audit target.** `AUDIT_TABLE` is checked as plain SQL identifiers
+  before it is interpolated into `CREATE`/`INSERT` (not parameterizable).
+- **Least privilege.** Scope the Service Key / private app token to exactly the
+  four `crm.lists.*` / `crm.objects.contacts.*` scopes the Flight uses.
+
+## Learn more
+
+- Flight mechanics (create, run, schedule, secrets): MCP `get_flight_guide`.
+- HubSpot Lists v3 API: [Lists API guide](https://developers.hubspot.com/docs/api-reference/crm-lists-v3/guide)
+  and [add/remove memberships](https://developers.hubspot.com/docs/api-reference/crm-lists-v3/memberships/put-crm-v3-lists-listId-memberships-add-and-remove).
+- HubSpot Service Keys (recommended credential for data integrations):
+  [docs](https://developers.hubspot.com/blog/hubspot-service-keys-the-right-api-credential-for-data-integrations).
+- Deeper MotherDuck/DuckDB questions: MCP `ask_docs_question`.
+- Files: [`flight.py`](flight.py) (the Flight source), [`requirements.txt`](requirements.txt)
+  (`duckdb`, `httpx` for the HubSpot API, and `tenacity` for retry/backoff).

--- a/flight-plans/flight-hubspot-list-sync/flight.py
+++ b/flight-plans/flight-hubspot-list-sync/flight.py
@@ -95,6 +95,13 @@ def resolve_token() -> str:
     )
 
 
+def quote_ident(ident: str) -> str:
+    """Quote a SQL identifier, doubling any embedded double quote so the value can
+    never break out of its quoted position (defense-in-depth alongside
+    validate_table)."""
+    return '"' + ident.replace('"', '""') + '"'
+
+
 def validate_table(value: str) -> str:
     """Validate a 'database.schema.table' name so it is safe to interpolate into
     SQL that cannot be parameterized (the audit ledger target)."""
@@ -221,12 +228,13 @@ class HubSpot:
 # --------------------------------------------------------------------------- #
 def write_audit(con: duckdb.DuckDBPyConnection, target: str, row: dict) -> None:
     validate_table(target)
-    db, schema, _table = target.split(".")
-    con.execute(f'CREATE DATABASE IF NOT EXISTS "{db}"')
-    con.execute(f'CREATE SCHEMA IF NOT EXISTS "{db}"."{schema}"')
+    db, schema, table = target.split(".")
+    qualified = f"{quote_ident(db)}.{quote_ident(schema)}.{quote_ident(table)}"
+    con.execute(f"CREATE DATABASE IF NOT EXISTS {quote_ident(db)}")
+    con.execute(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(db)}.{quote_ident(schema)}")
     con.execute(
         f"""
-        CREATE TABLE IF NOT EXISTS {target} (
+        CREATE TABLE IF NOT EXISTS {qualified} (
             run_id VARCHAR, run_at TIMESTAMPTZ, list_id VARCHAR, query_sha256 VARCHAR,
             n_emails BIGINT, n_resolved BIGINT, n_unmatched BIGINT,
             n_current_before BIGINT, n_added BIGINT, n_removed BIGINT,
@@ -235,7 +243,7 @@ def write_audit(con: duckdb.DuckDBPyConnection, target: str, row: dict) -> None:
         """
     )
     con.execute(
-        f"INSERT INTO {target} VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        f"INSERT INTO {qualified} VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         [
             row["run_id"], row["run_at"], row["list_id"], row["query_sha256"],
             row["n_emails"], row["n_resolved"], row["n_unmatched"],

--- a/flight-plans/flight-hubspot-list-sync/flight.py
+++ b/flight-plans/flight-hubspot-list-sync/flight.py
@@ -1,0 +1,363 @@
+"""MotherDuck -> HubSpot static-list sync flight.
+
+Runs a MotherDuck SQL query and reconciles the membership of a HubSpot static
+(MANUAL/SNAPSHOT) contact list so it exactly matches the query output. The query
+produces email addresses; the flight resolves them to HubSpot contact IDs, diffs
+against the list's current members, and applies the minimal set of add/remove
+operations via the Lists v3 `add-and-remove` endpoint.
+
+Design notes
+------------
+* Reconcile (diff), not clear+re-add: the list is never emptied, and a re-run
+  with unchanged data is a no-op (idempotent).
+* Emails with no matching HubSpot contact are skipped and logged (run succeeds).
+* Robust HTTP: retries with exponential backoff + jitter; honors 429 Retry-After.
+* Optional audit-ledger row per run.
+* DRY_RUN computes and logs the diff without applying it.
+
+Inputs (env vars; `config` is non-secret, the token comes from a secret)
+------------------------------------------------------------------------
+  QUERY                 (required) MotherDuck SQL; must output the email column.
+  HUBSPOT_LIST_ID       (required) Target static list ID to reconcile.
+  EMAIL_COLUMN          (default 'email') Column in the result holding emails.
+  OBJECT_TYPE_ID        (default '0-1') HubSpot list object type (contacts).
+  OBJECT_NAME           (default 'contacts') CRM object path for batch read.
+  ID_PROPERTY           (default 'email') Property used to resolve members.
+  BATCH_READ_SIZE       (default 100) Emails per batch-read call (HubSpot cap 100).
+  MEMBERSHIP_CHUNK_SIZE (default 1000) Record IDs per membership write call.
+  MAX_RETRIES           (default 5) Retry attempts per HTTP op.
+  RETRY_BASE_SECONDS    (default 2) Exponential backoff base.
+  DRY_RUN               (default 'false') 'true' = log the diff, change nothing.
+  AUDIT_TABLE           (default 'hubspot_list_sync.main.flight_tracker') '' to skip.
+
+Secret (flight_secret_names=['hubspot'])
+----------------------------------------
+  ACCESS_TOKEN -> env HUBSPOT_ACCESS_TOKEN (a HubSpot Service Key or private app
+  token). Locally you may instead set HUBSPOT_PRIVATE_APP_TOKEN.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+
+import duckdb
+import httpx
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_random,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("hubspot-list-sync")
+
+HUBSPOT_BASE = "https://api.hubapi.com"
+IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+class RetryableHTTPError(Exception):
+    """HTTP responses that should be retried (429 / 5xx)."""
+
+
+# --------------------------------------------------------------------------- #
+# Config / helpers
+# --------------------------------------------------------------------------- #
+def resolve_token() -> str:
+    """Find the HubSpot token without ever logging it. Accepts the deployed
+    secret env var (HUBSPOT_ACCESS_TOKEN), the common local name
+    (HUBSPOT_PRIVATE_APP_TOKEN), or any '*_ACCESS_TOKEN' / '*_PRIVATE_APP_TOKEN'
+    secret-injected var (excluding MOTHERDUCK_TOKEN)."""
+    for name in ("HUBSPOT_ACCESS_TOKEN", "HUBSPOT_PRIVATE_APP_TOKEN"):
+        val = os.environ.get(name, "").strip()
+        if val:
+            return val
+    for key, value in os.environ.items():
+        if key == "MOTHERDUCK_TOKEN":
+            continue
+        if (key.endswith("_ACCESS_TOKEN") or key.endswith("_PRIVATE_APP_TOKEN")) and value.strip():
+            return value.strip()
+    raise RuntimeError(
+        "No HubSpot token found. Set HUBSPOT_ACCESS_TOKEN (local) or attach the "
+        "'hubspot' flight secret with an ACCESS_TOKEN param."
+    )
+
+
+def validate_table(value: str) -> str:
+    """Validate a 'database.schema.table' name so it is safe to interpolate into
+    SQL that cannot be parameterized (the audit ledger target)."""
+    parts = value.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"AUDIT_TABLE must be 'database.schema.table', got {value!r}")
+    for part in parts:
+        if not IDENTIFIER_RE.fullmatch(part):
+            raise ValueError(f"AUDIT_TABLE part must be a simple identifier, got {part!r}")
+    return value
+
+
+def chunked(seq: list, size: int):
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]
+
+
+# --------------------------------------------------------------------------- #
+# HubSpot client
+# --------------------------------------------------------------------------- #
+class HubSpot:
+    """Thin HubSpot CRM v3 client with built-in retry/backoff. The token is held
+    only on the httpx client headers and is never logged."""
+
+    def __init__(self, token: str, max_retries: int, base_seconds: float):
+        self._client = httpx.Client(
+            base_url=HUBSPOT_BASE,
+            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            timeout=30.0,
+        )
+        self._max_retries = max_retries
+        self._base_seconds = base_seconds
+
+    def close(self) -> None:
+        self._client.close()
+
+    def _request(self, method: str, path: str, *, json=None, params=None) -> httpx.Response:
+        retryer = Retrying(
+            stop=stop_after_attempt(self._max_retries),
+            wait=wait_exponential(multiplier=self._base_seconds, max=60) + wait_random(0, 1),
+            retry=retry_if_exception_type((RetryableHTTPError, httpx.TransportError)),
+            reraise=True,
+        )
+        return retryer(self._do, method, path, json, params)
+
+    def _do(self, method: str, path: str, json, params) -> httpx.Response:
+        resp = self._client.request(method, path, json=json, params=params)
+        if resp.status_code == 429 or resp.status_code >= 500:
+            retry_after = resp.headers.get("Retry-After")
+            if retry_after:
+                try:
+                    time.sleep(min(float(retry_after), 60))
+                except ValueError:
+                    pass
+            raise RetryableHTTPError(f"{resp.status_code} {method} {path}: {resp.text[:200]}")
+        resp.raise_for_status()
+        return resp
+
+    def get_list(self, list_id: str) -> dict:
+        data = self._request("GET", f"/crm/v3/lists/{list_id}").json()
+        return data.get("list", data)
+
+    def get_current_member_ids(self, list_id: str) -> set[str]:
+        ids: set[str] = set()
+        after = None
+        while True:
+            params = {"limit": 250}
+            if after:
+                params["after"] = after
+            data = self._request("GET", f"/crm/v3/lists/{list_id}/memberships", params=params).json()
+            ids.update(str(r["recordId"]) for r in data.get("results", []))
+            after = data.get("paging", {}).get("next", {}).get("after")
+            if not after:
+                break
+        return ids
+
+    def resolve_emails(
+        self, emails: list[str], id_property: str, object_name: str, batch_size: int
+    ) -> tuple[set[str], list[str]]:
+        """Resolve a list of (normalized) emails to HubSpot record IDs. Returns
+        (set of resolved record IDs, list of unmatched emails)."""
+        resolved: set[str] = set()
+        unmatched: list[str] = []
+        for batch in chunked(emails, batch_size):
+            body = {
+                "idProperty": id_property,
+                "properties": ["email"],
+                "inputs": [{"id": e} for e in batch],
+            }
+            data = self._request(
+                "POST", f"/crm/v3/objects/{object_name}/batch/read", json=body
+            ).json()
+            matched: set[str] = set()
+            for r in data.get("results", []):
+                resolved.add(str(r["id"]))
+                email = (r.get("properties") or {}).get("email")
+                if email:
+                    matched.add(email.strip().lower())
+            unmatched.extend(e for e in batch if e not in matched)
+        return resolved, unmatched
+
+    def add_and_remove(
+        self, list_id: str, to_add: set[str], to_remove: set[str], chunk: int
+    ) -> tuple[int, int]:
+        add_list, rem_list = list(to_add), list(to_remove)
+        added = removed = 0
+        i = j = 0
+        while i < len(add_list) or j < len(rem_list):
+            a = add_list[i : i + chunk]
+            r = rem_list[j : j + chunk]
+            i += len(a)
+            j += len(r)
+            body = {"recordIdsToAdd": a, "recordIdsToRemove": r}
+            data = self._request(
+                "PUT", f"/crm/v3/lists/{list_id}/memberships/add-and-remove", json=body
+            ).json()
+            added += len(data.get("recordIdsAdded", a))
+            removed += len(data.get("recordIdsRemoved", r))
+        return added, removed
+
+
+# --------------------------------------------------------------------------- #
+# Audit ledger
+# --------------------------------------------------------------------------- #
+def write_audit(con: duckdb.DuckDBPyConnection, target: str, row: dict) -> None:
+    validate_table(target)
+    db, schema, _table = target.split(".")
+    con.execute(f'CREATE DATABASE IF NOT EXISTS "{db}"')
+    con.execute(f'CREATE SCHEMA IF NOT EXISTS "{db}"."{schema}"')
+    con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {target} (
+            run_id VARCHAR, run_at TIMESTAMPTZ, list_id VARCHAR, query_sha256 VARCHAR,
+            n_emails BIGINT, n_resolved BIGINT, n_unmatched BIGINT,
+            n_current_before BIGINT, n_added BIGINT, n_removed BIGINT,
+            n_final BIGINT, dry_run BOOLEAN, status VARCHAR, detail VARCHAR
+        )
+        """
+    )
+    con.execute(
+        f"INSERT INTO {target} VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        [
+            row["run_id"], row["run_at"], row["list_id"], row["query_sha256"],
+            row["n_emails"], row["n_resolved"], row["n_unmatched"],
+            row["n_current_before"], row["n_added"], row["n_removed"],
+            row["n_final"], row["dry_run"], row["status"], row["detail"],
+        ],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def main() -> None:
+    run_id = str(uuid.uuid4())
+    query = os.environ.get("QUERY", "").strip()
+    list_id = os.environ.get("HUBSPOT_LIST_ID", "").strip()
+    if not query:
+        raise RuntimeError("QUERY is required")
+    if not list_id:
+        raise RuntimeError("HUBSPOT_LIST_ID is required")
+
+    email_column = os.environ.get("EMAIL_COLUMN", "email").strip()
+    object_type_id = os.environ.get("OBJECT_TYPE_ID", "0-1").strip()
+    object_name = os.environ.get("OBJECT_NAME", "contacts").strip()
+    id_property = os.environ.get("ID_PROPERTY", "email").strip()
+    batch_read_size = int(os.environ.get("BATCH_READ_SIZE", "100"))
+    membership_chunk = int(os.environ.get("MEMBERSHIP_CHUNK_SIZE", "1000"))
+    max_retries = int(os.environ.get("MAX_RETRIES", "5"))
+    base_seconds = float(os.environ.get("RETRY_BASE_SECONDS", "2"))
+    dry_run = os.environ.get("DRY_RUN", "false").lower() == "true"
+    audit_table = os.environ.get("AUDIT_TABLE", "hubspot_list_sync.main.flight_tracker").strip()
+
+    token = resolve_token()
+    run_at = datetime.now(timezone.utc)
+    log.info("Run %s -> list %s (dry_run=%s)", run_id, list_id, dry_run)
+
+    con = duckdb.connect("md:")
+
+    # 1. Run the query and pull the email column (normalize + dedupe).
+    result = con.execute(query)
+    columns = [d[0] for d in result.description]
+    if email_column not in columns:
+        raise RuntimeError(f"QUERY result has no {email_column!r} column; columns={columns}")
+    idx = columns.index(email_column)
+    raw = [r[idx] for r in result.fetchall()]
+    emails = sorted({str(e).strip().lower() for e in raw if e is not None and str(e).strip()})
+    log.info("Query returned %d row(s); %d distinct non-empty email(s)", len(raw), len(emails))
+
+    hs = HubSpot(token, max_retries, base_seconds)
+    try:
+        # 2. Guard: the list must be a writable (MANUAL/SNAPSHOT) static list.
+        lst = hs.get_list(list_id)
+        ptype = lst.get("processingType")
+        if ptype not in ("MANUAL", "SNAPSHOT"):
+            raise RuntimeError(
+                f"List {list_id} processingType={ptype!r}; membership writes require "
+                "MANUAL or SNAPSHOT (a static list). Point at a dedicated static list."
+            )
+        otype = lst.get("objectTypeId")
+        if otype and otype != object_type_id:
+            log.warning("List objectTypeId=%s differs from OBJECT_TYPE_ID=%s", otype, object_type_id)
+        log.info("Target list %r processingType=%s objectTypeId=%s", lst.get("name"), ptype, otype)
+
+        # 3. Resolve emails -> record IDs (skip + log unmatched).
+        desired, unmatched = hs.resolve_emails(emails, id_property, object_name, batch_read_size)
+        if unmatched:
+            log.warning(
+                "%d email(s) had no matching %s and were skipped. sample=%s",
+                len(unmatched), object_name, unmatched[:10],
+            )
+
+        # 4. Diff against current membership.
+        current = hs.get_current_member_ids(list_id)
+        to_add = desired - current
+        to_remove = current - desired
+        log.info(
+            "desired=%d current=%d add=%d remove=%d unmatched=%d",
+            len(desired), len(current), len(to_add), len(to_remove), len(unmatched),
+        )
+
+        # 5. Apply (unless dry run).
+        if dry_run:
+            log.info("DRY_RUN=true; not applying changes.")
+            added = removed = 0
+            n_final = len(current)
+            status = "DRY_RUN"
+        else:
+            added, removed = hs.add_and_remove(list_id, to_add, to_remove, membership_chunk)
+            log.info("Applied: added=%d removed=%d", added, removed)
+            n_final = len(desired)
+            status = "SUCCEEDED"
+    finally:
+        hs.close()
+
+    # 6. Audit ledger.
+    if audit_table:
+        write_audit(
+            con,
+            audit_table,
+            {
+                "run_id": run_id,
+                "run_at": run_at,
+                "list_id": list_id,
+                "query_sha256": hashlib.sha256(query.encode()).hexdigest(),
+                "n_emails": len(emails),
+                "n_resolved": len(desired),
+                "n_unmatched": len(unmatched),
+                "n_current_before": len(current),
+                "n_added": added,
+                "n_removed": removed,
+                "n_final": n_final,
+                "dry_run": dry_run,
+                "status": status,
+                "detail": "",
+            },
+        )
+    con.close()
+    log.info(
+        "Summary: %s list=%s emails=%d resolved=%d unmatched=%d added=%d removed=%d final=%d",
+        status, list_id, len(emails), len(desired), len(unmatched), added, removed, n_final,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/flight-plans/flight-hubspot-list-sync/requirements.txt
+++ b/flight-plans/flight-hubspot-list-sync/requirements.txt
@@ -1,0 +1,3 @@
+duckdb==1.5.2
+httpx==0.28.1
+tenacity==9.0.0

--- a/flight-plans/flight-hubspot-list-sync/requirements.txt
+++ b/flight-plans/flight-hubspot-list-sync/requirements.txt
@@ -1,3 +1,3 @@
-duckdb==1.5.2
+duckdb==1.5.3
 httpx==0.28.1
 tenacity==9.0.0

--- a/scripts/build-catalog.py
+++ b/scripts/build-catalog.py
@@ -81,6 +81,8 @@ ALLOWED_TAGS = {
     "s3",
     # messaging and alerting
     "slack",
+    # crm and marketing
+    "hubspot",
     # external databases
     "postgres",
     "sqlite",


### PR DESCRIPTION
Adds a reusable Flight Plan template for data activation / reverse ETL: run a
MotherDuck SQL query to produce a list of emails and update (reconcile) a HubSpot
static contact list to match it.

What it does:
- **Reconcile-by-diff** via the HubSpot Lists v3 `add-and-remove` endpoint — applies only the delta, idempotent re-runs, never empties the list mid-run.
- Resolves emails → contact IDs via contacts `batch/read` (`idProperty=email`); unmatched emails are skipped and logged.
- Guards that the target list is `MANUAL`/`SNAPSHOT` (HubSpot rejects membership writes on `DYNAMIC` lists).
- Retries with jittered exponential backoff honoring `429 Retry-After`, a `DRY_RUN` mode, and an audit ledger.

Also adds `hubspot` to `ALLOWED_TAGS` in `scripts/build-catalog.py`; `uv run scripts/build-catalog.py` validates clean (31 items).

Files: `flight-plans/flight-hubspot-list-sync/{flight.py, requirements.txt, README.md}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)