### PR TITLE
Apache Iceberg import from S3 Tables

### DIFF
--- a/flight-plans/flight-s3tables-iceberg-ingest/README.md
+++ b/flight-plans/flight-s3tables-iceberg-ingest/README.md
@@ -1,27 +1,35 @@
 ---
-title: Copy an AWS S3 Tables Iceberg Table into MotherDuck
+title: Copy AWS S3 Tables (Iceberg) into MotherDuck With a Flight
 id: flight-s3tables-iceberg-ingest
 description: >-
-  A reusable Flight that copies a table from an AWS S3 Tables (Iceberg) catalog
-  into a native MotherDuck table with one CREATE OR REPLACE TABLE AS SELECT. Use
-  it for a config-driven, re-runnable S3 Tables to MotherDuck ingest.
+  A reusable Flight that copies tables from an AWS S3 Tables (Iceberg) catalog
+  into MotherDuck, one streaming full-refresh CREATE OR REPLACE per table, with
+  config-driven namespace/table selection, retries with backoff, and a per-table
+  audit log. Use it for a config-driven, re-runnable S3 Tables to MotherDuck ingest.
 type: template
 category: ingestion
 features: [flights]
 tags: [ingest, s3]
 ---
 
-# Copy an AWS S3 Tables Iceberg Table into MotherDuck
+# Copy AWS S3 Tables (Iceberg) into MotherDuck With a Flight
 
-Copies a table from an AWS S3 Tables Iceberg warehouse into a native MotherDuck table, so queries
-read a local table instead of scanning Iceberg on every run. Point it at any S3 Tables table, set
-how many rows to copy, and re-run it on a schedule to keep the copy current. Everything is driven by
-config, so you can reuse it without editing the code.
+Copies one or more tables from an AWS S3 Tables Iceberg warehouse into a MotherDuck database, so
+queries read native tables instead of scanning Iceberg on every run. Point it at a bucket, pick
+which namespaces and tables to copy, and re-run it on a schedule to keep the copies current.
+Everything is driven by config, so you can reuse it without editing the code.
+
+Each run attaches the S3 Tables catalog as a MotherDuck database (`TYPE ICEBERG`), discovers the
+tables in scope, and moves each with one statement:
+`CREATE OR REPLACE TABLE <target>."<namespace>"."<table>" AS SELECT * FROM <catalog>."<namespace>"."<table>"`.
+That is the whole load: atomic (swaps in one step), idempotent (a re-run replaces), and streaming
+(flat memory even on large tables). Tables land at `<target>.<namespace>.<table>`, preserving
+source namespace names, with a per-table log in `<target>.main.flight_tracker`.
 
 ## Prerequisite: an S3 secret
 
-The Flight holds no AWS keys of its own. It looks up a MotherDuck S3 secret by name
-(`MD_SECRET_NAME`, default `s3_tables_secret`), so create that secret once. The keys need S3 Tables
+The Flight holds no AWS keys. It references a MotherDuck S3 secret by name (`SECRET_NAME` in
+`flight.py`, default `s3_tables_secret`), so create that secret once. The keys need S3 Tables
 catalog access (`s3tables:*`) in the bucket's account, plus read on the data. Run this through the
 DuckDB CLI so `getenv()` reads the keys from your shell instead of writing them into the statement
 (drop `SESSION_TOKEN` for long-lived IAM keys):
@@ -42,47 +50,59 @@ Temporary keys expire, so re-create the secret when they lapse or use long-lived
 
 ## What you'll adjust
 
-Set these as Flight config, not by editing code.
+No code edits are required. Everything is read from Flight config and the MotherDuck secret.
 
-| Config key | Default | Purpose |
+| Knob | Default | Purpose |
 |---|---|---|
-| `TABLE_BUCKET_ARN` | ClickBench sample bucket ARN | S3 Tables bucket ARN. |
-| `SOURCE_NAMESPACE` | `clickbench` | Iceberg namespace in the bucket. |
-| `SOURCE_TABLE` | `hits` | Table to copy. |
-| `MD_SECRET_NAME` | `s3_tables_secret` | The MotherDuck S3 secret to use. |
-| `ICEBERG_DATABASE` | `iceberg_src` | Name for the attached catalog database. |
-| `DESTINATION_DATABASE` | `from_iceberg` | Target database. Created if missing. |
-| `DESTINATION_SCHEMA` | `main` | Target schema. Created if missing. |
-| `DESTINATION_TABLE` | (= `SOURCE_TABLE`) | Target table name. |
-| `ROW_LIMIT` | `100000` | Rows to copy. `0` copies the whole table. |
-| `AUDIT_TABLE` | `<dest_db>.<dest_schema>.flight_tracker` | Per-run log. Empty to skip. |
+| `TABLE_BUCKET_ARN` | ClickBench sample bucket ARN | S3 Tables bucket to copy from (`arn:aws:s3tables:…:bucket/…`). |
+| `TARGET_DATABASE` | `iceberg_ingest` | MotherDuck database for the copy (created if absent). Tables land at `<target>.<namespace>.<table>`. |
+| `INCLUDED_SCHEMAS` | (all) | Comma-separated namespaces to include. Empty = all. |
+| `EXCLUDED_SCHEMAS` | (none) | Comma-separated namespaces to drop. Exclude wins. |
+| `INCLUDED_TABLES` | (all) | Comma-separated `namespace.table` to include. Empty = all in selected namespaces. |
+| `EXCLUDED_TABLES` | (none) | Comma-separated `namespace.table` to drop. Exclude wins. |
+| `MAX_RETRIES` | `5` | Per-table retry attempts on transient errors. |
+| `RETRY_BASE_SECONDS` | `2` | Exponential-backoff multiplier (seconds). |
+| `s3_tables_secret` **secret** | (required) | MotherDuck `TYPE S3` secret with the AWS keys. Rename it only if you also change `SECRET_NAME` in `flight.py`. |
+
+Selection precedence: a table is copied only if its namespace passes the namespace gate and its
+`namespace.table` passes the table gate; excludes always win.
+
+To open the catalog, the attach needs one namespace that exists in the bucket. It comes from
+`INCLUDED_SCHEMAS`, else the namespaces named in `INCLUDED_TABLES`, else the sample namespace. Set
+`INCLUDED_SCHEMAS` (or `INCLUDED_TABLES`) when pointing at a non-sample bucket.
 
 ## Run it
 
-With the secret in place, the Flight needs only a MotherDuck token.
+With the secret in place, the Flight needs only a MotherDuck token; it reads no AWS env vars.
 
 ```bash
 export MOTHERDUCK_TOKEN=your_token_here
-ROW_LIMIT=1000 uv run --with duckdb==1.5.4 --no-project flight.py
+# scope it so a first run is cheap (the sample `hits` table is ~100M rows):
+export INCLUDED_TABLES=clickbench.probe,clickbench.ptest
+uv run --with-requirements requirements.txt flight.py
 ```
 
-This copies 1,000 rows into `from_iceberg.main.hits`. Change any default inline, for example
-`ROW_LIMIT=0` for the whole table.
+This copies the selected tables into `iceberg_ingest`, one full-refresh `CREATE OR REPLACE` each,
+and writes one `flight_tracker` row per table. One log line per table plus a summary; it exits
+non-zero if any table failed after retries.
 
 ### Deploy as a Flight
 
 Create it with `MD_CREATE_FLIGHT`, passing `name`, `source_code` ([`flight.py`](flight.py)),
-`requirements_txt` ([`requirements.txt`](requirements.txt)), and any `config` overrides. No secret
+`requirements_txt` ([`requirements.txt`](requirements.txt)), and a `config` with at least
+`TABLE_BUCKET_ARN` plus any `INCLUDED_*`/`EXCLUDED_*` scoping and `TARGET_DATABASE`. No secret
 arguments are needed: the Flight reads a stored `IN MOTHERDUCK` secret, and a MotherDuck token is
-attached for you. Run it once with `MD_RUN_FLIGHT`, then add a schedule with `MD_UPDATE_FLIGHT`. Use
-long-lived IAM keys for scheduled runs.
+attached for you. Run it once with `MD_RUN_FLIGHT`, confirm `flight_tracker` has one row per table,
+then add a schedule with `MD_UPDATE_FLIGHT`. Use long-lived IAM keys for scheduled runs.
 
 ## Caveats
 
-- If the secret's keys lack S3 Tables catalog access in the bucket's account, the run fails right
-  away with a clear message.
-- `ROW_LIMIT=0` reads the whole table (the sample `hits` is about 100M rows), so keep a limit for tests.
-- Needs `duckdb==1.5.4` (pinned in `requirements.txt`).
+- **Full refresh per table.** Cost scales with table size, not change volume. The sample `hits`
+  table is about 100M rows, so scope runs with `INCLUDED_TABLES`/`INCLUDED_SCHEMAS`.
+- **Dropped source tables are not removed** from the target; delete them yourself.
+- **Credentials are the usual failure.** Without S3 Tables catalog access in the bucket's account,
+  the attach fails right away with a clear message.
+- Needs the MotherDuck client in `duckdb==1.5.4` (pinned in `requirements.txt`).
 
 ## Learn more
 

--- a/flight-plans/flight-s3tables-iceberg-ingest/README.md
+++ b/flight-plans/flight-s3tables-iceberg-ingest/README.md
@@ -2,7 +2,7 @@
 title: Copy AWS S3 Tables (Iceberg) into MotherDuck With a Flight
 id: flight-s3tables-iceberg-ingest
 description: >-
-  A reusable Flight that copies tables from an AWS S3 Tables (Iceberg) catalog
+  A reusable Flight that copies tables from an Apache Iceberg (AWS S3 Tables) catalog
   into MotherDuck, one streaming full-refresh CREATE OR REPLACE per table, with
   config-driven namespace/table selection, retries with backoff, and a per-table
   audit log. Use it for a config-driven, re-runnable S3 Tables to MotherDuck ingest.
@@ -12,16 +12,16 @@ features: [flights]
 tags: [ingest, s3]
 ---
 
-# Copy AWS S3 Tables (Iceberg) into MotherDuck With a Flight
+# Copy Apache Iceberg (AWS S3 Tables) into MotherDuck With a Flight
 
-Copies one or more tables from an AWS S3 Tables Iceberg warehouse into a MotherDuck database, so
-queries read native tables instead of scanning Iceberg on every run. Point it at a bucket, pick
+Copies one or more tables from an AWS S3 Tables Iceberg Lakehouse into a MotherDuck database, so
+queries read native tables instead of scanning Iceberg. Point it at a bucket, pick
 which namespaces and tables to copy, and re-run it on a schedule to keep the copies current.
 Everything is driven by config, so you can reuse it without editing the code.
 
 Each run attaches the S3 Tables catalog as a MotherDuck database (`TYPE ICEBERG`), finds the tables
-in scope, and copies each one with a single `CREATE OR REPLACE TABLE ... AS SELECT *`. That
-statement is the whole load: it swaps the table in one step, a re-run just replaces it, and DuckDB
+in scope, and copies each one with a single `CREATE OR REPLACE TABLE ... AS SELECT *`. 
+It swaps the table in one step, a re-run just replaces it, and DuckDB
 streams the read straight into the write so memory stays flat on large tables. Copied tables land at
 `<target>.<namespace>.<table>`, and each run writes one row per table to `<target>.main.flight_tracker`.
 
@@ -39,13 +39,10 @@ CREATE OR REPLACE SECRET s3_tables_secret IN MOTHERDUCK (
     TYPE S3,
     KEY_ID getenv('AWS_ACCESS_KEY_ID'),
     SECRET getenv('AWS_SECRET_ACCESS_KEY'),
-    SESSION_TOKEN getenv('AWS_SESSION_TOKEN'),
     REGION 'us-east-1'
 );
 SQL
 ```
-
-Temporary keys expire, so re-create the secret when they lapse or use long-lived IAM keys.
 
 ## What you'll adjust
 
@@ -53,7 +50,7 @@ No code edits are required. Everything is read from Flight config and the Mother
 
 | Knob | Default | Purpose |
 |---|---|---|
-| `TABLE_BUCKET_ARN` | ClickBench sample bucket ARN | S3 Tables bucket to copy from (`arn:aws:s3tables:…:bucket/…`). |
+| `TABLE_BUCKET_ARN` | AWS Bucket ARN | S3 Tables bucket to copy from (`arn:aws:s3tables:…:bucket/…`). |
 | `TARGET_DATABASE` | `iceberg_ingest` | MotherDuck database for the copy (created if absent). Tables land at `<target>.<namespace>.<table>`. |
 | `INCLUDED_SCHEMAS` | (all) | Comma-separated namespaces to include. Empty = all. |
 | `EXCLUDED_SCHEMAS` | (none) | Comma-separated namespaces to drop. Exclude wins. |
@@ -70,7 +67,7 @@ To open the catalog, the attach needs one namespace that exists in the bucket. I
 `INCLUDED_SCHEMAS`, else the namespaces named in `INCLUDED_TABLES`, else the sample namespace. Set
 `INCLUDED_SCHEMAS` (or `INCLUDED_TABLES`) when pointing at a non-sample bucket.
 
-## Run it
+## Run it Locally
 
 With the secret in place, the Flight needs only a MotherDuck token; it reads no AWS env vars.
 
@@ -99,9 +96,6 @@ then add a schedule with `MD_UPDATE_FLIGHT`. Use long-lived IAM keys for schedul
 - Every run copies each selected table in full, so cost tracks table size, not how much changed.
   The sample `hits` table is about 100M rows, so scope runs with `INCLUDED_TABLES` or `INCLUDED_SCHEMAS`.
 - A table dropped at the source is not dropped from the target; remove it yourself.
-- If the secret's keys can't reach the S3 Tables catalog in the bucket's account, the attach fails
-  right away with a clear message.
-- Needs the MotherDuck client in `duckdb==1.5.4` (pinned in `requirements.txt`).
 
 ## Learn more
 

--- a/flight-plans/flight-s3tables-iceberg-ingest/README.md
+++ b/flight-plans/flight-s3tables-iceberg-ingest/README.md
@@ -10,6 +10,14 @@ type: template
 category: ingestion
 features: [flights]
 tags: [ingest, s3]
+prompt: >-
+  I have tables in an AWS S3 Tables Iceberg bucket and I want to copy them into
+  MotherDuck as native tables, on a schedule, so my queries stop re-scanning Iceberg
+  every time. I need to choose which namespaces and tables get copied, and I want a
+  re-run to just replace the data. Help me adapt the "Copy AWS S3 Tables (Iceberg)
+  into MotherDuck With a Flight" recipe to my own bucket and use case, using it as a
+  starting point.
+published_date: 2026-07-17
 ---
 
 # Copy Apache Iceberg (AWS S3 Tables) into MotherDuck With a Flight

--- a/flight-plans/flight-s3tables-iceberg-ingest/README.md
+++ b/flight-plans/flight-s3tables-iceberg-ingest/README.md
@@ -1,0 +1,90 @@
+---
+title: Copy an AWS S3 Tables Iceberg Table into MotherDuck
+id: flight-s3tables-iceberg-ingest
+description: >-
+  A reusable Flight that copies a table from an AWS S3 Tables (Iceberg) catalog
+  into a native MotherDuck table with one CREATE OR REPLACE TABLE AS SELECT. Use
+  it for a config-driven, re-runnable S3 Tables to MotherDuck ingest.
+type: template
+category: ingestion
+features: [flights]
+tags: [ingest, s3]
+---
+
+# Copy an AWS S3 Tables Iceberg Table into MotherDuck
+
+Copies a table from an AWS S3 Tables Iceberg warehouse into a native MotherDuck table, so queries
+read a local table instead of scanning Iceberg on every run. Point it at any S3 Tables table, set
+how many rows to copy, and re-run it on a schedule to keep the copy current. Everything is driven by
+config, so you can reuse it without editing the code.
+
+## Prerequisite: an S3 secret
+
+The Flight holds no AWS keys of its own. It looks up a MotherDuck S3 secret by name
+(`MD_SECRET_NAME`, default `s3_tables_secret`), so create that secret once. The keys need S3 Tables
+catalog access (`s3tables:*`) in the bucket's account, plus read on the data. Run this through the
+DuckDB CLI so `getenv()` reads the keys from your shell instead of writing them into the statement
+(drop `SESSION_TOKEN` for long-lived IAM keys):
+
+```bash
+motherduck_token="$YOUR_TOKEN" duckdb "md:" <<'SQL'
+CREATE OR REPLACE SECRET s3_tables_secret IN MOTHERDUCK (
+    TYPE S3,
+    KEY_ID getenv('AWS_ACCESS_KEY_ID'),
+    SECRET getenv('AWS_SECRET_ACCESS_KEY'),
+    SESSION_TOKEN getenv('AWS_SESSION_TOKEN'),
+    REGION 'us-east-1'
+);
+SQL
+```
+
+Temporary keys expire, so re-create the secret when they lapse or use long-lived IAM keys.
+
+## What you'll adjust
+
+Set these as Flight config, not by editing code.
+
+| Config key | Default | Purpose |
+|---|---|---|
+| `TABLE_BUCKET_ARN` | ClickBench sample bucket ARN | S3 Tables bucket ARN. |
+| `SOURCE_NAMESPACE` | `clickbench` | Iceberg namespace in the bucket. |
+| `SOURCE_TABLE` | `hits` | Table to copy. |
+| `MD_SECRET_NAME` | `s3_tables_secret` | The MotherDuck S3 secret to use. |
+| `ICEBERG_DATABASE` | `iceberg_src` | Name for the attached catalog database. |
+| `DESTINATION_DATABASE` | `from_iceberg` | Target database. Created if missing. |
+| `DESTINATION_SCHEMA` | `main` | Target schema. Created if missing. |
+| `DESTINATION_TABLE` | (= `SOURCE_TABLE`) | Target table name. |
+| `ROW_LIMIT` | `100000` | Rows to copy. `0` copies the whole table. |
+| `AUDIT_TABLE` | `<dest_db>.<dest_schema>.flight_tracker` | Per-run log. Empty to skip. |
+
+## Run it
+
+With the secret in place, the Flight needs only a MotherDuck token.
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+ROW_LIMIT=1000 uv run --with duckdb==1.5.4 --no-project flight.py
+```
+
+This copies 1,000 rows into `from_iceberg.main.hits`. Change any default inline, for example
+`ROW_LIMIT=0` for the whole table.
+
+### Deploy as a Flight
+
+Create it with `MD_CREATE_FLIGHT`, passing `name`, `source_code` ([`flight.py`](flight.py)),
+`requirements_txt` ([`requirements.txt`](requirements.txt)), and any `config` overrides. No secret
+arguments are needed: the Flight reads a stored `IN MOTHERDUCK` secret, and a MotherDuck token is
+attached for you. Run it once with `MD_RUN_FLIGHT`, then add a schedule with `MD_UPDATE_FLIGHT`. Use
+long-lived IAM keys for scheduled runs.
+
+## Caveats
+
+- If the secret's keys lack S3 Tables catalog access in the bucket's account, the run fails right
+  away with a clear message.
+- `ROW_LIMIT=0` reads the whole table (the sample `hits` is about 100M rows), so keep a limit for tests.
+- Needs `duckdb==1.5.4` (pinned in `requirements.txt`).
+
+## Learn more
+
+- Flights: the `get_flight_guide` MCP tool. S3 Tables, Iceberg, or secrets: `ask_docs_question`.
+- Files here: [`flight.py`](flight.py) and [`requirements.txt`](requirements.txt).

--- a/flight-plans/flight-s3tables-iceberg-ingest/README.md
+++ b/flight-plans/flight-s3tables-iceberg-ingest/README.md
@@ -19,12 +19,11 @@ queries read native tables instead of scanning Iceberg on every run. Point it at
 which namespaces and tables to copy, and re-run it on a schedule to keep the copies current.
 Everything is driven by config, so you can reuse it without editing the code.
 
-Each run attaches the S3 Tables catalog as a MotherDuck database (`TYPE ICEBERG`), discovers the
-tables in scope, and moves each with one statement:
-`CREATE OR REPLACE TABLE <target>."<namespace>"."<table>" AS SELECT * FROM <catalog>."<namespace>"."<table>"`.
-That is the whole load: atomic (swaps in one step), idempotent (a re-run replaces), and streaming
-(flat memory even on large tables). Tables land at `<target>.<namespace>.<table>`, preserving
-source namespace names, with a per-table log in `<target>.main.flight_tracker`.
+Each run attaches the S3 Tables catalog as a MotherDuck database (`TYPE ICEBERG`), finds the tables
+in scope, and copies each one with a single `CREATE OR REPLACE TABLE ... AS SELECT *`. That
+statement is the whole load: it swaps the table in one step, a re-run just replaces it, and DuckDB
+streams the read straight into the write so memory stays flat on large tables. Copied tables land at
+`<target>.<namespace>.<table>`, and each run writes one row per table to `<target>.main.flight_tracker`.
 
 ## Prerequisite: an S3 secret
 
@@ -97,11 +96,11 @@ then add a schedule with `MD_UPDATE_FLIGHT`. Use long-lived IAM keys for schedul
 
 ## Caveats
 
-- **Full refresh per table.** Cost scales with table size, not change volume. The sample `hits`
-  table is about 100M rows, so scope runs with `INCLUDED_TABLES`/`INCLUDED_SCHEMAS`.
-- **Dropped source tables are not removed** from the target; delete them yourself.
-- **Credentials are the usual failure.** Without S3 Tables catalog access in the bucket's account,
-  the attach fails right away with a clear message.
+- Every run copies each selected table in full, so cost tracks table size, not how much changed.
+  The sample `hits` table is about 100M rows, so scope runs with `INCLUDED_TABLES` or `INCLUDED_SCHEMAS`.
+- A table dropped at the source is not dropped from the target; remove it yourself.
+- If the secret's keys can't reach the S3 Tables catalog in the bucket's account, the attach fails
+  right away with a clear message.
 - Needs the MotherDuck client in `duckdb==1.5.4` (pinned in `requirements.txt`).
 
 ## Learn more

--- a/flight-plans/flight-s3tables-iceberg-ingest/README.md
+++ b/flight-plans/flight-s3tables-iceberg-ingest/README.md
@@ -54,14 +54,18 @@ No code edits are required. Everything is read from Flight config and the Mother
 | `TARGET_DATABASE` | `iceberg_ingest` | MotherDuck database for the copy (created if absent). Tables land at `<target>.<namespace>.<table>`. |
 | `INCLUDED_SCHEMAS` | (all) | Comma-separated namespaces to include. Empty = all. |
 | `EXCLUDED_SCHEMAS` | (none) | Comma-separated namespaces to drop. Exclude wins. |
-| `INCLUDED_TABLES` | (all) | Comma-separated `namespace.table` to include. Empty = all in selected namespaces. |
-| `EXCLUDED_TABLES` | (none) | Comma-separated `namespace.table` to drop. Exclude wins. |
+| `INCLUDED_TABLES` | (all) | Comma-separated `namespace.table`, or a bare `table` (matches that table in any namespace). Empty = all in selected namespaces. |
+| `EXCLUDED_TABLES` | (none) | Comma-separated `namespace.table` or bare `table` to drop. Exclude wins. |
 | `MAX_RETRIES` | `5` | Per-table retry attempts on transient errors. |
 | `RETRY_BASE_SECONDS` | `2` | Exponential-backoff multiplier (seconds). |
 | `s3_tables_secret` **secret** | (required) | MotherDuck `TYPE S3` secret with the AWS keys. Rename it only if you also change `SECRET_NAME` in `flight.py`. |
 
 Selection precedence: a table is copied only if its namespace passes the namespace gate and its
 `namespace.table` passes the table gate; excludes always win.
+
+Selection is forgiving about formats. Entries can be quoted or unquoted (`"clickbench"."hits"` is
+the same as `clickbench.hits`), fully qualified or a bare table name, and have surrounding
+whitespace. Matching is case-insensitive.
 
 To open the catalog, the attach needs one namespace that exists in the bucket. It comes from
 `INCLUDED_SCHEMAS`, else the namespaces named in `INCLUDED_TABLES`, else the sample namespace. Set

--- a/flight-plans/flight-s3tables-iceberg-ingest/flight.py
+++ b/flight-plans/flight-s3tables-iceberg-ingest/flight.py
@@ -1,51 +1,42 @@
 """
-AWS S3 Tables (Iceberg) -> MotherDuck native storage flight.
+AWS S3 Tables (Iceberg) -> MotherDuck batch copy flight.
 
-Copies a table from an AWS S3 Tables Iceberg warehouse into MotherDuck native storage by
-attaching the S3 Tables catalog as a first-class MotherDuck database and reading THROUGH it:
+Copies one or more tables from an AWS S3 Tables Iceberg catalog into a MotherDuck database.
+Each table is moved by a single streaming SQL statement:
 
-    CREATE OR REPLACE DATABASE <ice_db> (
-        TYPE ICEBERG,
-        WAREHOUSE '<s3tables-bucket-arn>',
-        ENDPOINT_TYPE 's3_tables',   -- derives the REST endpoint + SigV4 auth from the ARN
-        "secret" <secret>,           -- a pre-existing MotherDuck S3 secret (see below)
-        default_schema '<namespace>' -- the Iceberg namespace; REQUIRED
-    );
-    CREATE OR REPLACE TABLE <dest_db>."<schema>"."<table>" AS
-        SELECT * FROM <ice_db>."<namespace>"."<table>" [LIMIT <n>];
+    CREATE OR REPLACE TABLE <target>."<namespace>"."<table>" AS
+        SELECT * FROM <catalog>."<namespace>"."<table>";
 
-`CREATE OR REPLACE` on both statements makes the load atomic and idempotent (a re-run refreshes
-the catalog attach and fully replaces the destination). The default config copies the first 100k
-rows of the public ClickBench `hits` table into a `from_iceberg` database.
+That statement is the entire load. It is:
+    ATOMIC (CREATE OR REPLACE swaps in one step)
+    IDEMPOTENT (re-running fully replaces)
+    STREAMING (DuckDB pipelines the scan into the write, bounded memory)
+
+Tables land at <target>.<namespace>.<table>, preserving source namespace names. Per-table
+logging lands in <target>.main.flight_tracker.
 
 Credentials -- the flight uses NO AWS credentials
 -------------------------------------------------
-This flight assumes a **persistent MotherDuck S3 secret already exists** and simply references it
-by name (MD_SECRET_NAME). Create it once before the flight runs (see the README):
+It references a persistent MotherDuck S3 secret by name (SECRET_NAME below), created once out
+of band. The keys need S3 Tables catalog access (s3tables:*) in the bucket's account, plus read
+on the data:
 
     CREATE SECRET s3_tables_secret IN MOTHERDUCK (
         TYPE S3, KEY_ID '...', SECRET '...', SESSION_TOKEN '...', REGION 'us-east-1'
     );
 
-The secret's credentials must reach the S3 Tables catalog (s3tables:* actions) in the bucket's
-AWS account, plus the underlying data. Temporary (session-token) credentials expire with the
-token -- re-create the secret before a run when they lapse.
-
 Config (non-secret env vars)
 ----------------------------
-  TABLE_BUCKET_ARN      S3 Tables bucket ARN (arn:aws:s3tables:<region>:<acct>:bucket/<name>).
-  SOURCE_NAMESPACE      Iceberg namespace in the bucket (default 'clickbench').
-  SOURCE_TABLE          Iceberg table to copy (default 'hits').
-  MD_SECRET_NAME        Name of the pre-existing MotherDuck S3 secret (default 's3_tables_secret').
-  ICEBERG_DATABASE      Name for the attached Iceberg catalog database (default 'iceberg_src').
-  DESTINATION_DATABASE  MotherDuck database to create/write (default 'from_iceberg').
-  DESTINATION_SCHEMA    Destination schema (default 'main').
-  DESTINATION_TABLE     Destination table (default '' -> same as SOURCE_TABLE).
-  ROW_LIMIT             Rows to copy (default '100000'; '0' or '' = entire table).
-  AUDIT_TABLE           Audit ledger 'db.schema.table' (default '<dest_db>.<dest_schema>.flight_tracker'; '' to skip).
+    TABLE_BUCKET_ARN   S3 Tables bucket ARN (arn:aws:s3tables:<region>:<acct>:bucket/<name>).
+    TARGET_DATABASE    MotherDuck database to write into (default: iceberg_ingest).
+    INCLUDED_SCHEMAS / EXCLUDED_SCHEMAS   comma-separated Iceberg namespaces.
+    INCLUDED_TABLES  / EXCLUDED_TABLES    comma-separated, fully qualified namespace.table.
+    MAX_RETRIES (5)
+    RETRY_BASE_SECONDS (2)
 
-Requires the MotherDuck client extension that supports server-side Iceberg attach (duckdb 1.5.4);
-a 1.5.3 client can run count(*) through the attach but cannot project columns from it.
+To open the catalog, the attach needs one namespace that exists in the bucket. It is taken from
+INCLUDED_SCHEMAS, else the namespaces named in INCLUDED_TABLES, else the sample namespace. Set
+INCLUDED_SCHEMAS (or INCLUDED_TABLES) when pointing at a non-sample bucket.
 """
 
 from __future__ import annotations
@@ -55,8 +46,10 @@ import os
 import re
 import sys
 import uuid
+from datetime import datetime, timezone
 
 import duckdb
+from tenacity import Retrying, stop_after_attempt, wait_exponential, wait_random
 
 logging.basicConfig(
     level=logging.INFO,
@@ -65,26 +58,41 @@ logging.basicConfig(
 )
 log = logging.getLogger("s3tables-iceberg-ingest")
 
-IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 # arn:aws:s3tables:<region>:<account-id>:bucket/<bucket-name>
 ARN_RE = re.compile(r"arn:aws:s3tables:[a-z0-9-]+:\d+:bucket/[A-Za-z0-9][A-Za-z0-9_-]*")
-
 DEFAULT_ARN = "arn:aws:s3tables:us-east-1:114325331884:bucket/clickbench-iceberg"
+SAMPLE_NAMESPACE = "clickbench"  # namespace in the default sample bucket
+
+# DuckDB catalog schemas that are never copied, should they surface via discovery.
+SYSTEM_SCHEMAS = {"information_schema", "pg_catalog", "main"}
+
+# Persistent MotherDuck S3 secret the catalog attach references. Change it to point at another
+# secret (it must be a TYPE S3 secret created IN MOTHERDUCK).
+SECRET_NAME = "s3_tables_secret"
+
+# Local catalog name the S3 Tables bucket is attached as (TYPE ICEBERG). One source of truth.
+ICEBERG_ALIAS = "iceberg_src"
 
 
 # --------------------------------------------------------------------------- #
-# Small helpers
+# Small SQL / env helpers
 # --------------------------------------------------------------------------- #
-def env(name: str, default: str = "") -> str:
-    return os.environ.get(name, default).strip()
+def quote_ident(ident: str) -> str:
+    """Double-quote a SQL identifier, escaping embedded quotes, so names with special
+    characters or reserved words are handled correctly and safely."""
+    return '"' + ident.replace('"', '""') + '"'
 
 
-def validate_identifier(name: str, value: str) -> str:
-    """Reject anything that is not a plain SQL identifier before it reaches SQL that cannot be
-    parameterized (database / schema / table / secret names)."""
-    if not IDENTIFIER_RE.fullmatch(value):
-        raise ValueError(f"{name} must be a simple SQL identifier, got {value!r}")
-    return value
+def quote_literal(value: str) -> str:
+    """Single-quote a string literal, escaping embedded single quotes."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def csv_set(name: str) -> frozenset[str]:
+    """Turn a comma-separated env var into a clean set for membership filtering. Returns a set
+    of trimmed, non-empty values (empty set if unset)."""
+    raw = os.environ.get(name, "") or ""
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
 
 
 def validate_arn(value: str) -> str:
@@ -93,15 +101,44 @@ def validate_arn(value: str) -> str:
     return value
 
 
-def quote_ident(ident: str) -> str:
-    """Double-quote a SQL identifier, escaping embedded quotes (defense in depth alongside
-    validate_identifier)."""
-    return '"' + ident.replace('"', '""') + '"'
+# --------------------------------------------------------------------------- #
+# Table selection
+# --------------------------------------------------------------------------- #
+def is_selected(
+    schema: str,
+    table: str,
+    included_schemas: frozenset[str],
+    excluded_schemas: frozenset[str],
+    included_tables: frozenset[str],
+    excluded_tables: frozenset[str],
+) -> bool:
+    """Decide whether a discovered table is copied, applying the two include/exclude gates
+    where exclude always wins and system schemas are excluded."""
+    fqtn = f"{schema}.{table}"
+    if schema in SYSTEM_SCHEMAS:
+        return False
+    if included_schemas and schema not in included_schemas:
+        return False
+    if schema in excluded_schemas:
+        return False
+    if included_tables and fqtn not in included_tables:
+        return False
+    if fqtn in excluded_tables:
+        return False
+    return True
 
 
-def quote_literal(value: str) -> str:
-    """Single-quote a string literal, escaping embedded single quotes."""
-    return "'" + value.replace("'", "''") + "'"
+def pick_attach_namespace(
+    included_schemas: frozenset[str], included_tables: frozenset[str]
+) -> str:
+    """Choose one namespace to open the catalog with (Iceberg requires a default_schema that
+    exists). Prefer INCLUDED_SCHEMAS, then the namespaces in INCLUDED_TABLES, then the sample."""
+    if included_schemas:
+        return sorted(included_schemas)[0]
+    namespaces = sorted({fq.split(".", 1)[0] for fq in included_tables if "." in fq})
+    if namespaces:
+        return namespaces[0]
+    return SAMPLE_NAMESPACE
 
 
 # --------------------------------------------------------------------------- #
@@ -111,128 +148,160 @@ def connect_motherduck() -> duckdb.DuckDBPyConnection:
     return duckdb.connect("md:")
 
 
-def attach_iceberg_catalog(
-    con: duckdb.DuckDBPyConnection,
-    ice_db: str,
-    arn: str,
-    namespace: str,
-    secret_name: str,
-) -> None:
-    """Attach the S3 Tables catalog as a MotherDuck database of TYPE ICEBERG, using a pre-existing
-    MotherDuck S3 secret. CREATE OR REPLACE makes this idempotent and refreshes the attach (and
-    thus any rotated secret) on every run. Raises with a clear hint if the attach comes up as an
-    error catalog -- almost always a missing/underprivileged secret."""
+def attach_iceberg(con: duckdb.DuckDBPyConnection, arn: str, attach_namespace: str) -> None:
+    """Attach the S3 Tables bucket as a MotherDuck database of TYPE ICEBERG, using the
+    persistent S3 secret. CREATE OR REPLACE makes it idempotent. Raises with a clear hint if
+    the attach comes up as an error catalog (usually a missing/underprivileged secret or a
+    default_schema namespace that does not exist)."""
     con.execute(
-        f"CREATE OR REPLACE DATABASE {quote_ident(ice_db)} ("
+        f"CREATE OR REPLACE DATABASE {quote_ident(ICEBERG_ALIAS)} ("
         f"TYPE ICEBERG, "
         f"WAREHOUSE {quote_literal(arn)}, "
         f"ENDPOINT_TYPE 's3_tables', "
-        f'"secret" {quote_ident(secret_name)}, '
-        f"default_schema {quote_literal(namespace)})"
+        f'"secret" {quote_ident(SECRET_NAME)}, '
+        f"default_schema {quote_literal(attach_namespace)})"
     )
     is_error, message = con.execute(
         "SELECT is_error_catalog, error_message FROM MD_ATTACHED_DATABASES() WHERE alias = ?",
-        [ice_db],
+        [ICEBERG_ALIAS],
     ).fetchone()
     if is_error:
         raise RuntimeError(
-            f"Iceberg catalog '{ice_db}' attached as an ERROR catalog: {message}\n"
-            f"Ensure the MotherDuck secret '{secret_name}' exists and its AWS credentials have "
-            f"S3 Tables catalog (s3tables:*) permissions in the bucket's account. Create it with "
-            f"CREATE SECRET {secret_name} IN MOTHERDUCK (TYPE S3, ...); see the README."
+            f"Iceberg catalog attached as an ERROR catalog: {message}\n"
+            f"Check that secret {SECRET_NAME!r} exists with S3 Tables catalog (s3tables:*) "
+            f"permissions in the bucket's account, and that namespace {attach_namespace!r} exists."
         )
-    log.info("Attached S3 Tables catalog as %s (TYPE ICEBERG) via secret %s", ice_db, secret_name)
+    log.info("Attached %s as %s (TYPE ICEBERG) via secret %s", arn, ICEBERG_ALIAS, SECRET_NAME)
 
 
-def ensure_audit_table(con: duckdb.DuckDBPyConnection, audit: str) -> None:
-    db, schema, _ = audit.split(".")
-    con.execute(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(db)}.{quote_ident(schema)}")
+def ensure_target(con: duckdb.DuckDBPyConnection, target_db: str) -> None:
+    """Create the target database and the audit logging table up front."""
+    target = quote_ident(target_db)
+    con.execute(f"CREATE DATABASE IF NOT EXISTS {target}")
     con.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {audit_fqtn(audit)} (
-            run_id            VARCHAR,
-            run_at            TIMESTAMPTZ,
-            table_bucket_arn  VARCHAR,
-            source_namespace  VARCHAR,
-            source_table      VARCHAR,
-            iceberg_source    VARCHAR,
-            destination_table VARCHAR,
-            row_limit         BIGINT,
-            rows_loaded       BIGINT
-        )
-        """
+        f"CREATE TABLE IF NOT EXISTS {target}.main.flight_tracker ("
+        "  run_id               VARCHAR,"
+        "  flight_secret_name   VARCHAR,"
+        "  source_schema        VARCHAR,"
+        "  source_table         VARCHAR,"
+        "  destination_database VARCHAR,"
+        "  destination_schema   VARCHAR,"
+        "  destination_table    VARCHAR,"
+        "  rows_loaded          BIGINT,"
+        "  attempts             INTEGER,"
+        "  started_at           TIMESTAMP,"
+        "  finished_at          TIMESTAMP,"
+        "  update_ts            TIMESTAMP"
+        ")"
     )
 
 
-def audit_fqtn(audit: str) -> str:
-    return ".".join(quote_ident(p) for p in audit.split("."))
+# --------------------------------------------------------------------------- #
+# Discovery + per-table load
+# --------------------------------------------------------------------------- #
+def discover_tables(con: duckdb.DuckDBPyConnection) -> list[tuple[str, str]]:
+    """List the candidate source tables across every namespace in the attached catalog."""
+    rows = con.execute(
+        "SELECT schema_name, table_name FROM duckdb_tables() "
+        "WHERE database_name = ? ORDER BY schema_name, table_name",
+        [ICEBERG_ALIAS],
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+def load_table(con: duckdb.DuckDBPyConnection, target_db: str, schema: str, table: str) -> int:
+    """Move one table as a single atomic, idempotent, streaming CTAS. Returns the row count
+    the CTAS reports as inserted."""
+    tgt = f"{quote_ident(target_db)}.{quote_ident(schema)}.{quote_ident(table)}"
+    src = f"{quote_ident(ICEBERG_ALIAS)}.{quote_ident(schema)}.{quote_ident(table)}"
+    return con.execute(f"CREATE OR REPLACE TABLE {tgt} AS SELECT * FROM {src}").fetchone()[0]
+
+
+def record_success(
+    con: duckdb.DuckDBPyConnection, target_db: str, run_id: str,
+    schema: str, table: str, rows_loaded: int, attempts: int,
+    started_at: datetime, finished_at: datetime, update_ts: datetime,
+) -> None:
+    """After success, append a row to the audit table."""
+    con.execute(
+        f"INSERT INTO {quote_ident(target_db)}.main.flight_tracker "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [run_id, SECRET_NAME, schema, table, target_db, schema, table,
+         rows_loaded, attempts, started_at, finished_at, update_ts],
+    )
 
 
 # --------------------------------------------------------------------------- #
-# Main
+# main
 # --------------------------------------------------------------------------- #
 def main() -> None:
-    arn = validate_arn(env("TABLE_BUCKET_ARN", DEFAULT_ARN))
-    namespace = validate_identifier("SOURCE_NAMESPACE", env("SOURCE_NAMESPACE", "clickbench"))
-    source_table = validate_identifier("SOURCE_TABLE", env("SOURCE_TABLE", "hits"))
+    """Orchestrate the copy: connect, attach, discover, then load each selected table
+    sequentially with per-table retries/isolation and record results."""
+    RUN_ID = str(uuid.uuid4())
+    ARN = validate_arn(os.environ.get("TABLE_BUCKET_ARN", DEFAULT_ARN).strip())
+    TARGET_DB = os.environ.get("TARGET_DATABASE", "iceberg_ingest").strip() or "iceberg_ingest"
+    MAX_RETRIES = int(os.environ.get("MAX_RETRIES", "5"))
+    RETRY_BASE_SECONDS = float(os.environ.get("RETRY_BASE_SECONDS", "2"))
+    INCLUDED_SCHEMAS = csv_set("INCLUDED_SCHEMAS")
+    EXCLUDED_SCHEMAS = csv_set("EXCLUDED_SCHEMAS")
+    INCLUDED_TABLES = csv_set("INCLUDED_TABLES")
+    EXCLUDED_TABLES = csv_set("EXCLUDED_TABLES")
 
-    secret_name = validate_identifier("MD_SECRET_NAME", env("MD_SECRET_NAME", "s3_tables_secret"))
-    ice_db = validate_identifier("ICEBERG_DATABASE", env("ICEBERG_DATABASE", "iceberg_src"))
-
-    dest_db = validate_identifier("DESTINATION_DATABASE", env("DESTINATION_DATABASE", "from_iceberg"))
-    dest_schema = validate_identifier("DESTINATION_SCHEMA", env("DESTINATION_SCHEMA", "main"))
-    dest_table = validate_identifier(
-        "DESTINATION_TABLE", env("DESTINATION_TABLE", "") or source_table
-    )
-    destination = f"{quote_ident(dest_db)}.{quote_ident(dest_schema)}.{quote_ident(dest_table)}"
-
-    raw_limit = env("ROW_LIMIT", "100000")
-    row_limit = int(raw_limit) if raw_limit else 0
-    if row_limit < 0:
-        raise ValueError(f"ROW_LIMIT must be >= 0, got {row_limit}")
-
-    audit = env("AUDIT_TABLE", f"{dest_db}.{dest_schema}.flight_tracker")
+    log.info("Run %s -> target %r", RUN_ID, TARGET_DB)
 
     con = connect_motherduck()
+    attach_iceberg(con, ARN, pick_attach_namespace(INCLUDED_SCHEMAS, INCLUDED_TABLES))
+    ensure_target(con, TARGET_DB)
 
-    # Attach the S3 Tables catalog as a TYPE ICEBERG database, then read the source table THROUGH
-    # the catalog (no iceberg_scan, no metadata pointers, no AWS credentials in this flight).
-    attach_iceberg_catalog(con, ice_db, arn, namespace, secret_name)
-    iceberg_source = (
-        f"{quote_ident(ice_db)}.{quote_ident(namespace)}.{quote_ident(source_table)}"
-    )
+    all_tables = discover_tables(con)
+    selected = [
+        (s, t) for (s, t) in all_tables
+        if is_selected(s, t, INCLUDED_SCHEMAS, EXCLUDED_SCHEMAS, INCLUDED_TABLES, EXCLUDED_TABLES)
+    ]
+    log.info("Discovered %d table(s); %d selected after filters", len(all_tables), len(selected))
 
-    con.execute(f"CREATE DATABASE IF NOT EXISTS {quote_ident(dest_db)}")
-    con.execute(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(dest_db)}.{quote_ident(dest_schema)}")
+    if not selected:
+        log.warning("No tables selected - nothing to do.")
+        return
 
-    limit_clause = f" LIMIT {row_limit}" if row_limit > 0 else ""
-    log.info("Copying %s -> %s%s", iceberg_source, destination,
-             f" (first {row_limit} rows)" if row_limit > 0 else " (entire table)")
-    con.execute(
-        f"CREATE OR REPLACE TABLE {destination} AS "
-        f"SELECT * FROM {iceberg_source}{limit_clause}"
-    )
+    # Pre-create the target schemas (mirroring source namespace names) once.
+    for sch in sorted({s for (s, _) in selected}):
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(TARGET_DB)}.{quote_ident(sch)}")
 
-    rows_loaded = con.execute(f"SELECT count(*) FROM {destination}").fetchone()[0]
-    log.info("Loaded %s rows into %s", rows_loaded, destination)
+    started_all = datetime.now(timezone.utc)
+    failed: list[str] = []
+    succeeded = 0
+    rows_total = 0
 
-    if audit:
-        ensure_audit_table(con, audit)
-        con.execute(
-            f"INSERT INTO {audit_fqtn(audit)} VALUES (?, current_timestamp, ?, ?, ?, ?, ?, ?, ?)",
-            [
-                str(uuid.uuid4()),
-                arn,
-                namespace,
-                source_table,
-                f"{ice_db}.{namespace}.{source_table}",
-                f"{dest_db}.{dest_schema}.{dest_table}",
-                row_limit,
-                rows_loaded,
-            ],
+    for schema, table in selected:
+        fqtn = f"{schema}.{table}"
+        started = datetime.now(timezone.utc)
+        retryer = Retrying(
+            stop=stop_after_attempt(MAX_RETRIES),
+            wait=wait_exponential(multiplier=RETRY_BASE_SECONDS, max=60) + wait_random(0, 1),
+            reraise=True,
         )
+        try:
+            rows = retryer(load_table, con, TARGET_DB, schema, table)
+            attempts = retryer.statistics.get("attempt_number", 1)
+            finished = datetime.now(timezone.utc)
+            record_success(con, TARGET_DB, RUN_ID, schema, table, rows,
+                           attempts, started, finished, datetime.now(timezone.utc))
+            succeeded += 1
+            rows_total += rows
+            log.info("OK   %-50s %12d rows (attempts=%d)", fqtn, rows, attempts)
+        except Exception as exc:  # noqa: BLE001 - per-table isolation is intentional
+            attempts = retryer.statistics.get("attempt_number", 1)
+            failed.append(fqtn)
+            log.error("FAIL %-50s (attempts=%d) %s: %s", fqtn, attempts, type(exc).__name__, exc)
 
-    print(f"copied {namespace}.{source_table} -> {dest_db}.{dest_schema}.{dest_table}: {rows_loaded} rows")
+    total_seconds = (datetime.now(timezone.utc) - started_all).total_seconds()
+    log.info("Summary: %d succeeded, %d failed, %d rows in %.1fs (run %s)",
+             succeeded, len(failed), rows_total, total_seconds, RUN_ID)
+
+    if failed:
+        log.error("Failed tables: %s", ", ".join(failed))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/flight-plans/flight-s3tables-iceberg-ingest/flight.py
+++ b/flight-plans/flight-s3tables-iceberg-ingest/flight.py
@@ -63,8 +63,8 @@ ARN_RE = re.compile(r"arn:aws:s3tables:[a-z0-9-]+:\d+:bucket/[A-Za-z0-9][A-Za-z0
 DEFAULT_ARN = "arn:aws:s3tables:us-east-1:114325331884:bucket/clickbench-iceberg"
 SAMPLE_NAMESPACE = "clickbench"  # namespace in the default sample bucket
 
-# DuckDB catalog schemas that are never copied, should they surface via discovery.
-SYSTEM_SCHEMAS = {"information_schema", "pg_catalog", "main"}
+# Postgres catalog schemas that are never copied, should they surface via discovery.
+SYSTEM_SCHEMAS = {"information_schema", "pg_catalog", "pg_toast"}
 
 # Persistent MotherDuck S3 secret the catalog attach references. Change it to point at another
 # secret (it must be a TYPE S3 secret created IN MOTHERDUCK).
@@ -144,10 +144,6 @@ def pick_attach_namespace(
 # --------------------------------------------------------------------------- #
 # Connection + setup
 # --------------------------------------------------------------------------- #
-def connect_motherduck() -> duckdb.DuckDBPyConnection:
-    return duckdb.connect("md:")
-
-
 def attach_iceberg(con: duckdb.DuckDBPyConnection, arn: str, attach_namespace: str) -> None:
     """Attach the S3 Tables bucket as a MotherDuck database of TYPE ICEBERG, using the
     persistent S3 secret. CREATE OR REPLACE makes it idempotent. Raises with a clear hint if
@@ -249,7 +245,7 @@ def main() -> None:
 
     log.info("Run %s -> target %r", RUN_ID, TARGET_DB)
 
-    con = connect_motherduck()
+    con = duckdb.connect("md:")
     attach_iceberg(con, ARN, pick_attach_namespace(INCLUDED_SCHEMAS, INCLUDED_TABLES))
     ensure_target(con, TARGET_DB)
 

--- a/flight-plans/flight-s3tables-iceberg-ingest/flight.py
+++ b/flight-plans/flight-s3tables-iceberg-ingest/flight.py
@@ -15,14 +15,14 @@ That statement is the entire load. It is:
 Tables land at <target>.<namespace>.<table>, preserving source namespace names. Per-table
 logging lands in <target>.main.flight_tracker.
 
-Credentials -- the flight uses NO AWS credentials
+Credentials 
 -------------------------------------------------
 It references a persistent MotherDuck S3 secret by name (SECRET_NAME below), created once out
 of band. The keys need S3 Tables catalog access (s3tables:*) in the bucket's account, plus read
 on the data:
 
     CREATE SECRET s3_tables_secret IN MOTHERDUCK (
-        TYPE S3, KEY_ID '...', SECRET '...', SESSION_TOKEN '...', REGION 'us-east-1'
+        TYPE S3, KEY_ID '...', SECRET '...', REGION 'us-east-1'
     );
 
 Config (non-secret env vars)

--- a/flight-plans/flight-s3tables-iceberg-ingest/flight.py
+++ b/flight-plans/flight-s3tables-iceberg-ingest/flight.py
@@ -60,6 +60,7 @@ log = logging.getLogger("s3tables-iceberg-ingest")
 
 # arn:aws:s3tables:<region>:<account-id>:bucket/<bucket-name>
 ARN_RE = re.compile(r"arn:aws:s3tables:[a-z0-9-]+:\d+:bucket/[A-Za-z0-9][A-Za-z0-9_-]*")
+IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 DEFAULT_ARN = "arn:aws:s3tables:us-east-1:114325331884:bucket/clickbench-iceberg"
 SAMPLE_NAMESPACE = "clickbench"  # namespace in the default sample bucket
 
@@ -88,6 +89,20 @@ def quote_literal(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
 
+def qualified_name(*parts: str) -> str:
+    """Join parts into a fully-qualified SQL name with every part quoted, so identifiers from
+    config or catalog discovery cannot break out of their quotes (SQL-injection safe)."""
+    return ".".join(quote_ident(part) for part in parts)
+
+
+def validate_identifier(name: str, value: str) -> str:
+    """Reject a config value that is not a plain SQL identifier before it is used as one
+    (defense in depth alongside quote_ident)."""
+    if not IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a simple SQL identifier, got {value!r}")
+    return value
+
+
 def csv_set(name: str) -> frozenset[str]:
     """Turn a comma-separated env var into a clean set for membership filtering. Returns a set
     of trimmed, non-empty values (empty set if unset)."""
@@ -114,7 +129,7 @@ def is_selected(
 ) -> bool:
     """Decide whether a discovered table is copied, applying the two include/exclude gates
     where exclude always wins and system schemas are excluded."""
-    fqtn = f"{schema}.{table}"
+    fqtn = f"{schema}.{table}"  # include/exclude membership only; never interpolated into SQL
     if schema in SYSTEM_SCHEMAS:
         return False
     if included_schemas and schema not in included_schemas:
@@ -172,10 +187,9 @@ def attach_iceberg(con: duckdb.DuckDBPyConnection, arn: str, attach_namespace: s
 
 def ensure_target(con: duckdb.DuckDBPyConnection, target_db: str) -> None:
     """Create the target database and the audit logging table up front."""
-    target = quote_ident(target_db)
-    con.execute(f"CREATE DATABASE IF NOT EXISTS {target}")
+    con.execute(f"CREATE DATABASE IF NOT EXISTS {quote_ident(target_db)}")
     con.execute(
-        f"CREATE TABLE IF NOT EXISTS {target}.main.flight_tracker ("
+        f"CREATE TABLE IF NOT EXISTS {qualified_name(target_db, 'main', 'flight_tracker')} ("
         "  run_id               VARCHAR,"
         "  flight_secret_name   VARCHAR,"
         "  source_schema        VARCHAR,"
@@ -208,8 +222,8 @@ def discover_tables(con: duckdb.DuckDBPyConnection) -> list[tuple[str, str]]:
 def load_table(con: duckdb.DuckDBPyConnection, target_db: str, schema: str, table: str) -> int:
     """Move one table as a single atomic, idempotent, streaming CTAS. Returns the row count
     the CTAS reports as inserted."""
-    tgt = f"{quote_ident(target_db)}.{quote_ident(schema)}.{quote_ident(table)}"
-    src = f"{quote_ident(ICEBERG_ALIAS)}.{quote_ident(schema)}.{quote_ident(table)}"
+    tgt = qualified_name(target_db, schema, table)
+    src = qualified_name(ICEBERG_ALIAS, schema, table)
     return con.execute(f"CREATE OR REPLACE TABLE {tgt} AS SELECT * FROM {src}").fetchone()[0]
 
 
@@ -220,7 +234,7 @@ def record_success(
 ) -> None:
     """After success, append a row to the audit table."""
     con.execute(
-        f"INSERT INTO {quote_ident(target_db)}.main.flight_tracker "
+        f"INSERT INTO {qualified_name(target_db, 'main', 'flight_tracker')} "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         [run_id, SECRET_NAME, schema, table, target_db, schema, table,
          rows_loaded, attempts, started_at, finished_at, update_ts],
@@ -235,7 +249,10 @@ def main() -> None:
     sequentially with per-table retries/isolation and record results."""
     RUN_ID = str(uuid.uuid4())
     ARN = validate_arn(os.environ.get("TABLE_BUCKET_ARN", DEFAULT_ARN).strip())
-    TARGET_DB = os.environ.get("TARGET_DATABASE", "iceberg_ingest").strip() or "iceberg_ingest"
+    TARGET_DB = validate_identifier(
+        "TARGET_DATABASE",
+        os.environ.get("TARGET_DATABASE", "iceberg_ingest").strip() or "iceberg_ingest",
+    )
     MAX_RETRIES = int(os.environ.get("MAX_RETRIES", "5"))
     RETRY_BASE_SECONDS = float(os.environ.get("RETRY_BASE_SECONDS", "2"))
     INCLUDED_SCHEMAS = csv_set("INCLUDED_SCHEMAS")
@@ -262,7 +279,7 @@ def main() -> None:
 
     # Pre-create the target schemas (mirroring source namespace names) once.
     for sch in sorted({s for (s, _) in selected}):
-        con.execute(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(TARGET_DB)}.{quote_ident(sch)}")
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS {qualified_name(TARGET_DB, sch)}")
 
     started_all = datetime.now(timezone.utc)
     failed: list[str] = []
@@ -270,7 +287,7 @@ def main() -> None:
     rows_total = 0
 
     for schema, table in selected:
-        fqtn = f"{schema}.{table}"
+        fqtn = f"{schema}.{table}"  # logging only; SQL names go through qualified_name()
         started = datetime.now(timezone.utc)
         retryer = Retrying(
             stop=stop_after_attempt(MAX_RETRIES),

--- a/flight-plans/flight-s3tables-iceberg-ingest/flight.py
+++ b/flight-plans/flight-s3tables-iceberg-ingest/flight.py
@@ -1,0 +1,239 @@
+"""
+AWS S3 Tables (Iceberg) -> MotherDuck native storage flight.
+
+Copies a table from an AWS S3 Tables Iceberg warehouse into MotherDuck native storage by
+attaching the S3 Tables catalog as a first-class MotherDuck database and reading THROUGH it:
+
+    CREATE OR REPLACE DATABASE <ice_db> (
+        TYPE ICEBERG,
+        WAREHOUSE '<s3tables-bucket-arn>',
+        ENDPOINT_TYPE 's3_tables',   -- derives the REST endpoint + SigV4 auth from the ARN
+        "secret" <secret>,           -- a pre-existing MotherDuck S3 secret (see below)
+        default_schema '<namespace>' -- the Iceberg namespace; REQUIRED
+    );
+    CREATE OR REPLACE TABLE <dest_db>."<schema>"."<table>" AS
+        SELECT * FROM <ice_db>."<namespace>"."<table>" [LIMIT <n>];
+
+`CREATE OR REPLACE` on both statements makes the load atomic and idempotent (a re-run refreshes
+the catalog attach and fully replaces the destination). The default config copies the first 100k
+rows of the public ClickBench `hits` table into a `from_iceberg` database.
+
+Credentials -- the flight uses NO AWS credentials
+-------------------------------------------------
+This flight assumes a **persistent MotherDuck S3 secret already exists** and simply references it
+by name (MD_SECRET_NAME). Create it once before the flight runs (see the README):
+
+    CREATE SECRET s3_tables_secret IN MOTHERDUCK (
+        TYPE S3, KEY_ID '...', SECRET '...', SESSION_TOKEN '...', REGION 'us-east-1'
+    );
+
+The secret's credentials must reach the S3 Tables catalog (s3tables:* actions) in the bucket's
+AWS account, plus the underlying data. Temporary (session-token) credentials expire with the
+token -- re-create the secret before a run when they lapse.
+
+Config (non-secret env vars)
+----------------------------
+  TABLE_BUCKET_ARN      S3 Tables bucket ARN (arn:aws:s3tables:<region>:<acct>:bucket/<name>).
+  SOURCE_NAMESPACE      Iceberg namespace in the bucket (default 'clickbench').
+  SOURCE_TABLE          Iceberg table to copy (default 'hits').
+  MD_SECRET_NAME        Name of the pre-existing MotherDuck S3 secret (default 's3_tables_secret').
+  ICEBERG_DATABASE      Name for the attached Iceberg catalog database (default 'iceberg_src').
+  DESTINATION_DATABASE  MotherDuck database to create/write (default 'from_iceberg').
+  DESTINATION_SCHEMA    Destination schema (default 'main').
+  DESTINATION_TABLE     Destination table (default '' -> same as SOURCE_TABLE).
+  ROW_LIMIT             Rows to copy (default '100000'; '0' or '' = entire table).
+  AUDIT_TABLE           Audit ledger 'db.schema.table' (default '<dest_db>.<dest_schema>.flight_tracker'; '' to skip).
+
+Requires the MotherDuck client extension that supports server-side Iceberg attach (duckdb 1.5.4);
+a 1.5.3 client can run count(*) through the attach but cannot project columns from it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sys
+import uuid
+
+import duckdb
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("s3tables-iceberg-ingest")
+
+IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+# arn:aws:s3tables:<region>:<account-id>:bucket/<bucket-name>
+ARN_RE = re.compile(r"arn:aws:s3tables:[a-z0-9-]+:\d+:bucket/[A-Za-z0-9][A-Za-z0-9_-]*")
+
+DEFAULT_ARN = "arn:aws:s3tables:us-east-1:114325331884:bucket/clickbench-iceberg"
+
+
+# --------------------------------------------------------------------------- #
+# Small helpers
+# --------------------------------------------------------------------------- #
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def validate_identifier(name: str, value: str) -> str:
+    """Reject anything that is not a plain SQL identifier before it reaches SQL that cannot be
+    parameterized (database / schema / table / secret names)."""
+    if not IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a simple SQL identifier, got {value!r}")
+    return value
+
+
+def validate_arn(value: str) -> str:
+    if not ARN_RE.fullmatch(value):
+        raise ValueError(f"TABLE_BUCKET_ARN is not a valid S3 Tables bucket ARN: {value!r}")
+    return value
+
+
+def quote_ident(ident: str) -> str:
+    """Double-quote a SQL identifier, escaping embedded quotes (defense in depth alongside
+    validate_identifier)."""
+    return '"' + ident.replace('"', '""') + '"'
+
+
+def quote_literal(value: str) -> str:
+    """Single-quote a string literal, escaping embedded single quotes."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+# --------------------------------------------------------------------------- #
+# Connection + setup
+# --------------------------------------------------------------------------- #
+def connect_motherduck() -> duckdb.DuckDBPyConnection:
+    return duckdb.connect("md:")
+
+
+def attach_iceberg_catalog(
+    con: duckdb.DuckDBPyConnection,
+    ice_db: str,
+    arn: str,
+    namespace: str,
+    secret_name: str,
+) -> None:
+    """Attach the S3 Tables catalog as a MotherDuck database of TYPE ICEBERG, using a pre-existing
+    MotherDuck S3 secret. CREATE OR REPLACE makes this idempotent and refreshes the attach (and
+    thus any rotated secret) on every run. Raises with a clear hint if the attach comes up as an
+    error catalog -- almost always a missing/underprivileged secret."""
+    con.execute(
+        f"CREATE OR REPLACE DATABASE {quote_ident(ice_db)} ("
+        f"TYPE ICEBERG, "
+        f"WAREHOUSE {quote_literal(arn)}, "
+        f"ENDPOINT_TYPE 's3_tables', "
+        f'"secret" {quote_ident(secret_name)}, '
+        f"default_schema {quote_literal(namespace)})"
+    )
+    is_error, message = con.execute(
+        "SELECT is_error_catalog, error_message FROM MD_ATTACHED_DATABASES() WHERE alias = ?",
+        [ice_db],
+    ).fetchone()
+    if is_error:
+        raise RuntimeError(
+            f"Iceberg catalog '{ice_db}' attached as an ERROR catalog: {message}\n"
+            f"Ensure the MotherDuck secret '{secret_name}' exists and its AWS credentials have "
+            f"S3 Tables catalog (s3tables:*) permissions in the bucket's account. Create it with "
+            f"CREATE SECRET {secret_name} IN MOTHERDUCK (TYPE S3, ...); see the README."
+        )
+    log.info("Attached S3 Tables catalog as %s (TYPE ICEBERG) via secret %s", ice_db, secret_name)
+
+
+def ensure_audit_table(con: duckdb.DuckDBPyConnection, audit: str) -> None:
+    db, schema, _ = audit.split(".")
+    con.execute(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(db)}.{quote_ident(schema)}")
+    con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {audit_fqtn(audit)} (
+            run_id            VARCHAR,
+            run_at            TIMESTAMPTZ,
+            table_bucket_arn  VARCHAR,
+            source_namespace  VARCHAR,
+            source_table      VARCHAR,
+            iceberg_source    VARCHAR,
+            destination_table VARCHAR,
+            row_limit         BIGINT,
+            rows_loaded       BIGINT
+        )
+        """
+    )
+
+
+def audit_fqtn(audit: str) -> str:
+    return ".".join(quote_ident(p) for p in audit.split("."))
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> None:
+    arn = validate_arn(env("TABLE_BUCKET_ARN", DEFAULT_ARN))
+    namespace = validate_identifier("SOURCE_NAMESPACE", env("SOURCE_NAMESPACE", "clickbench"))
+    source_table = validate_identifier("SOURCE_TABLE", env("SOURCE_TABLE", "hits"))
+
+    secret_name = validate_identifier("MD_SECRET_NAME", env("MD_SECRET_NAME", "s3_tables_secret"))
+    ice_db = validate_identifier("ICEBERG_DATABASE", env("ICEBERG_DATABASE", "iceberg_src"))
+
+    dest_db = validate_identifier("DESTINATION_DATABASE", env("DESTINATION_DATABASE", "from_iceberg"))
+    dest_schema = validate_identifier("DESTINATION_SCHEMA", env("DESTINATION_SCHEMA", "main"))
+    dest_table = validate_identifier(
+        "DESTINATION_TABLE", env("DESTINATION_TABLE", "") or source_table
+    )
+    destination = f"{quote_ident(dest_db)}.{quote_ident(dest_schema)}.{quote_ident(dest_table)}"
+
+    raw_limit = env("ROW_LIMIT", "100000")
+    row_limit = int(raw_limit) if raw_limit else 0
+    if row_limit < 0:
+        raise ValueError(f"ROW_LIMIT must be >= 0, got {row_limit}")
+
+    audit = env("AUDIT_TABLE", f"{dest_db}.{dest_schema}.flight_tracker")
+
+    con = connect_motherduck()
+
+    # Attach the S3 Tables catalog as a TYPE ICEBERG database, then read the source table THROUGH
+    # the catalog (no iceberg_scan, no metadata pointers, no AWS credentials in this flight).
+    attach_iceberg_catalog(con, ice_db, arn, namespace, secret_name)
+    iceberg_source = (
+        f"{quote_ident(ice_db)}.{quote_ident(namespace)}.{quote_ident(source_table)}"
+    )
+
+    con.execute(f"CREATE DATABASE IF NOT EXISTS {quote_ident(dest_db)}")
+    con.execute(f"CREATE SCHEMA IF NOT EXISTS {quote_ident(dest_db)}.{quote_ident(dest_schema)}")
+
+    limit_clause = f" LIMIT {row_limit}" if row_limit > 0 else ""
+    log.info("Copying %s -> %s%s", iceberg_source, destination,
+             f" (first {row_limit} rows)" if row_limit > 0 else " (entire table)")
+    con.execute(
+        f"CREATE OR REPLACE TABLE {destination} AS "
+        f"SELECT * FROM {iceberg_source}{limit_clause}"
+    )
+
+    rows_loaded = con.execute(f"SELECT count(*) FROM {destination}").fetchone()[0]
+    log.info("Loaded %s rows into %s", rows_loaded, destination)
+
+    if audit:
+        ensure_audit_table(con, audit)
+        con.execute(
+            f"INSERT INTO {audit_fqtn(audit)} VALUES (?, current_timestamp, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                str(uuid.uuid4()),
+                arn,
+                namespace,
+                source_table,
+                f"{ice_db}.{namespace}.{source_table}",
+                f"{dest_db}.{dest_schema}.{dest_table}",
+                row_limit,
+                rows_loaded,
+            ],
+        )
+
+    print(f"copied {namespace}.{source_table} -> {dest_db}.{dest_schema}.{dest_table}: {rows_loaded} rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/flight-plans/flight-s3tables-iceberg-ingest/flight.py
+++ b/flight-plans/flight-s3tables-iceberg-ingest/flight.py
@@ -30,9 +30,13 @@ Config (non-secret env vars)
     TABLE_BUCKET_ARN   S3 Tables bucket ARN (arn:aws:s3tables:<region>:<acct>:bucket/<name>).
     TARGET_DATABASE    MotherDuck database to write into (default: iceberg_ingest).
     INCLUDED_SCHEMAS / EXCLUDED_SCHEMAS   comma-separated Iceberg namespaces.
-    INCLUDED_TABLES  / EXCLUDED_TABLES    comma-separated, fully qualified namespace.table.
+    INCLUDED_TABLES  / EXCLUDED_TABLES    comma-separated table specs: `namespace.table` or a
+                                          bare `table` (matches that table in any namespace).
     MAX_RETRIES (5)
     RETRY_BASE_SECONDS (2)
+
+Selection is case-insensitive and format tolerant: each namespace/table entry may be given with
+or without double quotes ("clickbench"."hits" == clickbench.hits) and with surrounding whitespace.
 
 To open the catalog, the attach needs one namespace that exists in the bucket. It is taken from
 INCLUDED_SCHEMAS, else the namespaces named in INCLUDED_TABLES, else the sample namespace. Set
@@ -103,11 +107,61 @@ def validate_identifier(name: str, value: str) -> str:
     return value
 
 
-def csv_set(name: str) -> frozenset[str]:
-    """Turn a comma-separated env var into a clean set for membership filtering. Returns a set
-    of trimmed, non-empty values (empty set if unset)."""
-    raw = os.environ.get(name, "") or ""
-    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+def _unquote(part: str) -> str:
+    """Strip one layer of surrounding double quotes from an identifier and unescape "" -> "."""
+    part = part.strip()
+    if len(part) >= 2 and part[0] == '"' and part[-1] == '"':
+        return part[1:-1].replace('""', '"')
+    return part
+
+
+def _split_outside_quotes(text: str, sep: str) -> list[str]:
+    """Split text on sep, ignoring separators that fall inside double quotes."""
+    parts, buf, in_quotes = [], [], False
+    for ch in text:
+        if ch == '"':
+            in_quotes = not in_quotes
+            buf.append(ch)
+        elif ch == sep and not in_quotes:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    parts.append("".join(buf))
+    return parts
+
+
+def _split_ref(text: str) -> list[str]:
+    """Parse a dotted identifier reference into its unquoted parts, honoring double quotes (a
+    '.' inside quotes is literal). Empty parts (stray dots/whitespace) are dropped."""
+    return [u for p in _split_outside_quotes(text, ".") if (u := _unquote(p))]
+
+
+def csv_schemas(name: str) -> frozenset[str]:
+    """Parse a comma-separated namespace list into a set of unquoted names, tolerant of optional
+    double quotes and whitespace. Case is preserved here; matching casefolds (see is_selected)."""
+    out = set()
+    for entry in _split_outside_quotes(os.environ.get(name, "") or "", ","):
+        parts = _split_ref(entry)
+        if parts:
+            out.add(".".join(parts))
+    return frozenset(out)
+
+
+def csv_tables(name: str) -> frozenset[tuple[str | None, str]]:
+    """Parse a comma-separated table list into a set of (namespace|None, table) specs. Accepts a
+    fully-qualified `namespace.table` or a bare `table`, each part optionally double-quoted, with
+    surrounding whitespace. Case is preserved here; matching casefolds (see is_selected)."""
+    out = set()
+    for entry in _split_outside_quotes(os.environ.get(name, "") or "", ","):
+        parts = _split_ref(entry)
+        if not parts:
+            continue
+        if len(parts) == 1:
+            out.add((None, parts[0]))
+        else:
+            out.add((".".join(parts[:-1]), parts[-1]))
+    return frozenset(out)
 
 
 def validate_arn(value: str) -> str:
@@ -124,35 +178,50 @@ def is_selected(
     table: str,
     included_schemas: frozenset[str],
     excluded_schemas: frozenset[str],
-    included_tables: frozenset[str],
-    excluded_tables: frozenset[str],
+    included_tables: frozenset[tuple[str | None, str]],
+    excluded_tables: frozenset[tuple[str | None, str]],
 ) -> bool:
-    """Decide whether a discovered table is copied, applying the two include/exclude gates
-    where exclude always wins and system schemas are excluded."""
-    fqtn = f"{schema}.{table}"  # include/exclude membership only; never interpolated into SQL
-    if schema in SYSTEM_SCHEMAS:
+    """Decide whether a discovered table is copied. Matching is case-insensitive and format
+    tolerant: schema specs are plain names and table specs are (namespace|None, table), already
+    unquoted by csv_schemas/csv_tables. A bare-table spec matches that table in any namespace.
+    Exclude always wins; system schemas are always dropped."""
+    s = schema.casefold()
+    t = table.casefold()
+    inc_s = {x.casefold() for x in included_schemas}
+    exc_s = {x.casefold() for x in excluded_schemas}
+
+    if s in SYSTEM_SCHEMAS:
         return False
-    if included_schemas and schema not in included_schemas:
+    if inc_s and s not in inc_s:
         return False
-    if schema in excluded_schemas:
+    if s in exc_s:
         return False
-    if included_tables and fqtn not in included_tables:
+
+    def matches(specs: frozenset[tuple[str | None, str]]) -> bool:
+        for spec_schema, spec_table in specs:
+            if spec_table.casefold() == t and (spec_schema is None or spec_schema.casefold() == s):
+                return True
         return False
-    if fqtn in excluded_tables:
+
+    if included_tables and not matches(included_tables):
+        return False
+    if matches(excluded_tables):
         return False
     return True
 
 
-def pick_attach_namespace(
-    included_schemas: frozenset[str], included_tables: frozenset[str]
-) -> str:
+def pick_attach_namespace() -> str:
     """Choose one namespace to open the catalog with (Iceberg requires a default_schema that
-    exists). Prefer INCLUDED_SCHEMAS, then the namespaces in INCLUDED_TABLES, then the sample."""
-    if included_schemas:
-        return sorted(included_schemas)[0]
-    namespaces = sorted({fq.split(".", 1)[0] for fq in included_tables if "." in fq})
-    if namespaces:
-        return namespaces[0]
+    exists). Prefer INCLUDED_SCHEMAS, then the namespaces named in INCLUDED_TABLES, then the
+    sample. Uses the name as typed (quotes stripped), preserving case for the catalog."""
+    for entry in _split_outside_quotes(os.environ.get("INCLUDED_SCHEMAS", "") or "", ","):
+        parts = _split_ref(entry)
+        if parts:
+            return ".".join(parts)
+    for entry in _split_outside_quotes(os.environ.get("INCLUDED_TABLES", "") or "", ","):
+        parts = _split_ref(entry)
+        if len(parts) >= 2:
+            return ".".join(parts[:-1])
     return SAMPLE_NAMESPACE
 
 
@@ -255,15 +324,15 @@ def main() -> None:
     )
     MAX_RETRIES = int(os.environ.get("MAX_RETRIES", "5"))
     RETRY_BASE_SECONDS = float(os.environ.get("RETRY_BASE_SECONDS", "2"))
-    INCLUDED_SCHEMAS = csv_set("INCLUDED_SCHEMAS")
-    EXCLUDED_SCHEMAS = csv_set("EXCLUDED_SCHEMAS")
-    INCLUDED_TABLES = csv_set("INCLUDED_TABLES")
-    EXCLUDED_TABLES = csv_set("EXCLUDED_TABLES")
+    INCLUDED_SCHEMAS = csv_schemas("INCLUDED_SCHEMAS")
+    EXCLUDED_SCHEMAS = csv_schemas("EXCLUDED_SCHEMAS")
+    INCLUDED_TABLES = csv_tables("INCLUDED_TABLES")
+    EXCLUDED_TABLES = csv_tables("EXCLUDED_TABLES")
 
     log.info("Run %s -> target %r", RUN_ID, TARGET_DB)
 
     con = duckdb.connect("md:")
-    attach_iceberg(con, ARN, pick_attach_namespace(INCLUDED_SCHEMAS, INCLUDED_TABLES))
+    attach_iceberg(con, ARN, pick_attach_namespace())
     ensure_target(con, TARGET_DB)
 
     all_tables = discover_tables(con)

--- a/flight-plans/flight-s3tables-iceberg-ingest/requirements.txt
+++ b/flight-plans/flight-s3tables-iceberg-ingest/requirements.txt
@@ -1,0 +1,3 @@
+# 1.5.4 ships the MotherDuck client extension that can project columns from a server-side
+# Iceberg (S3 Tables) attach. 1.5.3 can only count(*) through the attach.
+duckdb==1.5.4

--- a/flight-plans/flight-s3tables-iceberg-ingest/requirements.txt
+++ b/flight-plans/flight-s3tables-iceberg-ingest/requirements.txt
@@ -1,3 +1,6 @@
-# 1.5.4 ships the MotherDuck client extension that can project columns from a server-side
-# Iceberg (S3 Tables) attach. 1.5.3 can only count(*) through the attach.
+# 1.5.4 ships the MotherDuck client that can project columns from a server-side Iceberg
+# (S3 Tables) attach. `tenacity` provides the jittered exponential-backoff retry around each
+# per-table load. The `iceberg` extension is a DuckDB core extension loaded server-side, not a
+# pip package, so it is not listed here.
 duckdb==1.5.4
+tenacity==9.0.0


### PR DESCRIPTION
This is a Flight Plan cookbook that mirrors the Postgres full refresh sync cookbook. It will take an S3 Table bucket and sync the entire thing over to MotherDuck table by table. 

A future cookbook should be made that is incremental. 